### PR TITLE
Experiment: The Division HUD aesthetic

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -12,6 +12,9 @@
   <link rel="icon" href="/assets/favicon-62.png" sizes="62x62" type="image/png">
   <link rel="icon" href="/assets/favicon-192.png" sizes="192x192" type="image/png">
 
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Rajdhani:wght@300;400;500;600;700&family=Share+Tech+Mono&display=swap" rel="stylesheet">
   <script async src="/vendor/fa-all.min.js"></script>
   <link rel="stylesheet" href="/styles.css">
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,4 @@
 <script>
-  import '@fontsource-variable/inter';
   let { children } = $props();
 </script>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,9 @@
 <script>
   import { onMount } from 'svelte';
+  import { fade } from 'svelte/transition';
 
-  let lights = $state(false);
+  let lights = $state(true);
+  let booting = $state(true);
 
   $effect(() => {
     document.body.classList.toggle('background-white', lights);
@@ -27,9 +29,10 @@
     if (saved === 'on' || saved === 'off') {
       lights = saved === 'on';
     } else {
-      lights = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      setCookie('lights', lights ? 'on' : 'off');
+      lights = true;
+      setCookie('lights', 'on');
     }
+    setTimeout(() => { booting = false; }, 3400);
   });
 </script>
 
@@ -44,46 +47,124 @@
   <meta name="twitter:site" content="@paulogdm" />
 </svelte:head>
 
-<div class="container">
-  <div class="px-4 py-4 clearfix">
-    <button
-      onclick={changeBackground}
-      class="lightbulb float-left animated fadeIn p-2"
-      aria-label="Toggle light/dark mode"
-    >
-      <i class="far fa-lightbulb fa-fw fa-2x"></i>
-    </button>
+{#if booting}
+<div class="boot-screen" out:fade={{ duration: 500 }}>
+  <div class="boot-logo">
+    <svg viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="40" cy="40" r="36" stroke="currentColor" stroke-width="1.5" stroke-dasharray="6 3" class="ring-rotate"/>
+      <circle cx="40" cy="40" r="24" stroke="currentColor" stroke-width="1"/>
+      <line x1="40" y1="16" x2="40" y2="24" stroke="currentColor" stroke-width="2.5"/>
+      <line x1="40" y1="56" x2="40" y2="64" stroke="currentColor" stroke-width="2.5"/>
+      <line x1="16" y1="40" x2="24" y2="40" stroke="currentColor" stroke-width="2.5"/>
+      <line x1="56" y1="40" x2="64" y2="40" stroke="currentColor" stroke-width="2.5"/>
+      <circle cx="40" cy="40" r="5" fill="currentColor"/>
+      <circle cx="40" cy="40" r="2" fill="#07090C"/>
+    </svg>
   </div>
-
-  <div class="my-4 text-center align-middle">
-    <div class="me-size animated fadeIn">
-      <img
-        src="/assets/me.jpg"
-        class="mx-auto d-block {lights ? 'me-white' : 'me-black'}"
-        alt="paulogdm"
-        draggable="false"
-      >
-    </div>
-
-    <div class="my-5 py-2 animated fadeIn">
-      <h1>paulogdm</h1>
-      <h6 class="mt-3" aria-label="Useful links">
-        <a class="mx-2" href="&#77;&#97;&#73;&#76;&#84;&#79;&#58;&#109;&#101;&#64;&#112;&#97;&#117;&#108;&#111;&#103;&#100;&#109;&#46;&#99;&#111;&#109;" target="_blank" rel="noopener noreferrer" aria-label="Email">
-          <i class="far fa-envelope fa-fw fa-lg"></i>
-        </a>
-        <a class="mx-2" href="https://x.com/paulogdm" target="_blank" rel="noopener noreferrer" aria-label="X">
-          <i class="fab fa-x-twitter fa-fw fa-lg"></i>
-        </a>
-        <a class="mx-2" href="https://www.linkedin.com/in/paulogdm/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
-          <i class="fab fa-linkedin-in fa-fw fa-lg"></i>
-        </a>
-        <a class="mx-2" href="https://github.com/paulogdm" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
-          <i class="fab fa-github fa-fw fa-lg"></i>
-        </a>
-        <a class="mx-2" href="https://stackoverflow.com/users/2665655/paulogdm" target="_blank" rel="noopener noreferrer" aria-label="Stack Overflow">
-          <i class="fab fa-stack-overflow fa-fw fa-lg"></i>
-        </a>
-      </h6>
-    </div>
+  <div class="boot-log">
+    <div class="boot-line" style="--d:0.1s">SHD NETWORK v4.2.1 INITIALIZING...</div>
+    <div class="boot-line" style="--d:0.7s">BIOMETRIC AUTHENTICATION: VERIFIED</div>
+    <div class="boot-line" style="--d:1.3s">AGENT PROFILE DECRYPTION: COMPLETE</div>
+    <div class="boot-line" style="--d:1.9s">LOCATION SERVICES: ACTIVE</div>
+    <div class="boot-line active" style="--d:2.5s">FIELD STATUS: <span>OPERATIONAL</span></div>
   </div>
 </div>
+
+{:else}
+
+<div class="hud-container" in:fade={{ duration: 600 }}>
+
+  <div class="classification-bar">
+    SHD NETWORK // AUTHORIZED PERSONNEL ONLY // CLASSIFICATION: UNRESTRICTED
+  </div>
+
+  <header class="hud-header">
+    <div class="header-left">
+      <svg class="shd-icon" viewBox="0 0 40 40" fill="none">
+        <circle cx="20" cy="20" r="17" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 2" class="ring-rotate"/>
+        <circle cx="20" cy="20" r="11" stroke="currentColor" stroke-width="1"/>
+        <line x1="20" y1="9" x2="20" y2="13" stroke="currentColor" stroke-width="2"/>
+        <line x1="20" y1="27" x2="20" y2="31" stroke="currentColor" stroke-width="2"/>
+        <line x1="9" y1="20" x2="13" y2="20" stroke="currentColor" stroke-width="2"/>
+        <line x1="27" y1="20" x2="31" y2="20" stroke="currentColor" stroke-width="2"/>
+        <circle cx="20" cy="20" r="2.5" fill="currentColor"/>
+      </svg>
+      <span class="header-label">SHD NETWORK</span>
+    </div>
+    <div class="header-right">
+      <span class="status-dot"></span>
+      <span class="mono dim">AGENT_ONLINE</span>
+    </div>
+  </header>
+
+  <main class="agent-stage">
+    <div class="agent-card">
+      <div class="corner tl"></div>
+      <div class="corner tr"></div>
+      <div class="corner bl"></div>
+      <div class="corner br"></div>
+
+      <div class="card-inner">
+
+        <div class="photo-col">
+          <div class="photo-frame">
+            <div class="corner tl"></div>
+            <div class="corner tr"></div>
+            <div class="corner bl"></div>
+            <div class="corner br"></div>
+            <img src="/assets/me.jpg" alt="paulogdm" class="agent-photo" draggable="false">
+            <div class="photo-scan"></div>
+            <div class="photo-badge">IDENTITY VERIFIED</div>
+          </div>
+          <div class="gear-readout">
+            <span class="mono dim small">GEAR SCORE</span>
+            <span class="mono orange large">500</span>
+          </div>
+        </div>
+
+        <div class="info-col">
+          <div class="mono dim small lspaced">AGENT // ALPHA-1</div>
+          <h1 class="agent-name">paulogdm</h1>
+          <div class="status-row">
+            <span class="pulse-dot"></span>
+            <span class="mono small">STATUS: <span class="orange">ACTIVE</span></span>
+          </div>
+          <div class="mono dim small lspaced" style="margin-top:0.2rem">STRATEGIC HOMELAND DIVISION</div>
+
+          <div class="divider"></div>
+
+          <div class="mono dim small lspaced" style="margin-bottom:0.65rem">// SECURE CHANNELS</div>
+          <div class="link-grid">
+            <a class="link-item" href="&#77;&#97;&#73;&#76;&#84;&#79;&#58;&#109;&#101;&#64;&#112;&#97;&#117;&#108;&#111;&#103;&#100;&#109;&#46;&#99;&#111;&#109;" target="_blank" rel="noopener noreferrer" aria-label="Email">
+              <i class="far fa-envelope fa-fw"></i><span>EMAIL</span>
+            </a>
+            <a class="link-item" href="https://x.com/paulogdm" target="_blank" rel="noopener noreferrer" aria-label="X">
+              <i class="fab fa-x-twitter fa-fw"></i><span>X</span>
+            </a>
+            <a class="link-item" href="https://www.linkedin.com/in/paulogdm/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
+              <i class="fab fa-linkedin-in fa-fw"></i><span>LINKEDIN</span>
+            </a>
+            <a class="link-item" href="https://github.com/paulogdm" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <i class="fab fa-github fa-fw"></i><span>GITHUB</span>
+            </a>
+            <a class="link-item" href="https://stackoverflow.com/users/2665655/paulogdm" target="_blank" rel="noopener noreferrer" aria-label="Stack Overflow">
+              <i class="fab fa-stack-overflow fa-fw"></i><span>S. OVERFLOW</span>
+            </a>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </main>
+
+  <footer class="hud-footer">
+    <button onclick={changeBackground} class="mode-btn" aria-label="Toggle light/dark mode">
+      <i class="far fa-lightbulb fa-fw"></i>
+      <span class="mono small">{lights ? 'NIGHT_OPS' : 'DAYLIGHT'}</span>
+    </button>
+    <div class="mono dim small">CLASSIFICATION: UNRESTRICTED</div>
+    <div class="mono dim small">38.8951°N 77.0369°W</div>
+  </footer>
+
+</div>
+{/if}

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,157 +1,379 @@
-/* ── Reset / base ───────────────────────────────────────────── */
-*, *::before, *::after {
-  box-sizing: border-box;
+/* ── Division Protocol // paulogdm.com ───────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg-0: #07090C;
+  --bg-1: #0C1118;
+  --bg-2: #131B24;
+  --orange: #E57820;
+  --orange-b: #FF9040;
+  --orange-dim: rgba(229, 120, 32, 0.10);
+  --orange-border: rgba(229, 120, 32, 0.28);
+  --orange-glow: 0 0 28px rgba(229, 120, 32, 0.20);
+  --text: #D8DCE4;
+  --dim: #5E6A7A;
+  --green: #4CB880;
+  --f-display: 'Bebas Neue', sans-serif;
+  --f-body: 'Rajdhani', sans-serif;
+  --f-mono: 'Share Tech Mono', monospace;
+}
+
+/* Daylight mode */
+body.background-black {
+  --bg-0: #E4DDD0;
+  --bg-1: #D0C8B8;
+  --bg-2: #BFBAA8;
+  --text: #0A0C10;
+  --dim: #5A5040;
+  --orange-dim: rgba(180, 80, 0, 0.08);
+  --orange-border: rgba(180, 80, 0, 0.35);
 }
 
 body {
-  margin: 0;
-  font-family: 'Inter Variable', 'Inter', sans-serif;
+  background: var(--bg-0);
+  color: var(--text);
+  font-family: var(--f-body);
   font-size: 1rem;
   line-height: 1.5;
+  min-height: 100vh;
+  overflow-x: hidden;
+  cursor: crosshair;
+  transition: background 0.4s ease, color 0.4s ease;
 }
 
-h1 {
-  font-size: 2.5rem;
-  font-weight: 300;
-  margin-top: 0;
-  margin-bottom: 0.5rem;
-  transition: all 1s ease;
-  text-shadow: rgba(0,0,0,.01) 0 0 1px;
+/* Hex grid */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='56' height='100'%3E%3Cpolygon fill='none' stroke='rgba%28229%2C120%2C32%2C0.055%29' stroke-width='0.8' points='28%2C2 54%2C16 54%2C84 28%2C98 2%2C84 2%2C16'/%3E%3C/svg%3E");
+  pointer-events: none;
+  z-index: 0;
+}
+body.background-black::before { opacity: 0.35; }
+
+/* Scanlines */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.012) 2px, rgba(0,0,0,0.012) 4px);
+  pointer-events: none;
+  z-index: 1;
 }
 
-h6 {
-  font-size: 1rem;
-  font-weight: 300;
-  margin-top: 0;
-  margin-bottom: 0.5rem;
-  line-height: 1.7em;
+/* ── Boot screen ─────────────────────────────────────────────── */
+.boot-screen {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-0);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
 }
 
-a {
-  text-decoration: none;
-  transition: all 1s ease;
-  color: inherit;
+.boot-logo {
+  color: var(--orange);
+  width: 90px;
+  height: 90px;
+  animation: logo-in 0.5s ease both;
+}
+@keyframes logo-in {
+  from { opacity: 0; transform: scale(0.75); }
+  to   { opacity: 1; transform: scale(1); }
 }
 
-a:hover {
-  text-decoration: none;
-  color: #FF6600;
+.ring-rotate {
+  transform-origin: center;
+  animation: spin 10s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.boot-log {
+  font-family: var(--f-mono);
+  font-size: 0.78rem;
+  color: var(--dim);
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  width: 300px;
+}
+.boot-line {
+  opacity: 0;
+  animation: line-in 0.25s ease both;
+  animation-delay: var(--d, 0s);
+  display: flex;
+  gap: 0.5rem;
+}
+.boot-line::before { content: '>'; color: var(--orange); flex-shrink: 0; }
+.boot-line.active { color: var(--orange); }
+.boot-line.active span { font-weight: bold; }
+@keyframes line-in {
+  from { opacity: 0; transform: translateX(-6px); }
+  to   { opacity: 1; transform: translateX(0); }
 }
 
-/* ── Bootstrap replacements ─────────────────────────────────── */
-.container {
+/* ── HUD layout ──────────────────────────────────────────────── */
+.hud-container {
+  position: relative;
+  z-index: 2;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.classification-bar {
+  background: var(--orange);
+  color: var(--bg-0);
+  text-align: center;
+  font-family: var(--f-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.18em;
+  padding: 0.22rem 1rem;
+  font-weight: bold;
+  transition: background 0.4s;
+}
+
+/* ── Header ──────────────────────────────────────────────────── */
+.hud-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.7rem 1.5rem;
+  border-bottom: 1px solid var(--orange-border);
+  background: var(--bg-1);
+  transition: background 0.4s, border-color 0.4s;
+}
+.header-left { display: flex; align-items: center; gap: 0.75rem; }
+.shd-icon { width: 32px; height: 32px; color: var(--orange); }
+.header-label {
+  font-family: var(--f-mono);
+  font-size: 0.72rem;
+  color: var(--orange);
+  letter-spacing: 0.12em;
+}
+.header-right { display: flex; align-items: center; gap: 0.5rem; }
+
+.status-dot {
+  width: 7px; height: 7px;
+  background: var(--green);
+  border-radius: 50%;
+  animation: pulse-g 2.5s ease-in-out infinite;
+}
+@keyframes pulse-g {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(76,184,128,0.5); }
+  50%       { opacity: 0.75; box-shadow: 0 0 0 5px rgba(76,184,128,0); }
+}
+
+/* ── Shared typography helpers ───────────────────────────────── */
+.mono    { font-family: var(--f-mono); }
+.dim     { color: var(--dim); transition: color 0.4s; }
+.orange  { color: var(--orange); }
+.small   { font-size: 0.68rem; }
+.lspaced { letter-spacing: 0.1em; }
+
+/* ── Agent stage ─────────────────────────────────────────────── */
+.agent-stage {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1rem;
+}
+
+.agent-card {
+  position: relative;
+  background: var(--bg-1);
+  border: 1px solid var(--orange-border);
+  padding: 2rem;
+  max-width: 580px;
   width: 100%;
-  max-width: 960px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 1rem;
-  padding-right: 1rem;
+  transition: background 0.4s, border-color 0.4s, box-shadow 0.3s;
+}
+.agent-card:hover { box-shadow: var(--orange-glow); }
+
+/* Corner brackets */
+.corner {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+}
+.corner.tl { top: -1px;    left: -1px;  border-top: 2px solid var(--orange); border-left:  2px solid var(--orange); }
+.corner.tr { top: -1px;    right: -1px; border-top: 2px solid var(--orange); border-right: 2px solid var(--orange); }
+.corner.bl { bottom: -1px; left: -1px;  border-bottom: 2px solid var(--orange); border-left:  2px solid var(--orange); }
+.corner.br { bottom: -1px; right: -1px; border-bottom: 2px solid var(--orange); border-right: 2px solid var(--orange); }
+
+.card-inner {
+  display: flex;
+  gap: 1.75rem;
+  align-items: flex-start;
 }
 
-.d-block     { display: block; }
-.text-center { text-align: center; }
-.mx-auto     { margin-left: auto; margin-right: auto; }
-.float-left  { float: left; }
-.clearfix::after { content: ""; display: table; clear: both; }
-
-.p-2  { padding: 0.5rem; }
-.px-4 { padding-left: 1.5rem; padding-right: 1.5rem; }
-.py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-.py-4 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
-.mt-3 { margin-top: 1rem; }
-.my-4 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
-.my-5 { margin-top: 3rem; margin-bottom: 3rem; }
-.mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
-
-/* ── Animations (replaces animate.css) ──────────────────────── */
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+/* ── Photo column ────────────────────────────────────────────── */
+.photo-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  flex-shrink: 0;
 }
 
-.animated { animation-duration: 1s; animation-fill-mode: both; }
-.fadeIn   { animation-name: fadeIn; }
-
-/* ── Theme ──────────────────────────────────────────────────── */
-.background-white {
-  background-color: #000000;
-  transition: all 0.3s ease;
-  color: #FFFFFF;
+.photo-frame {
+  position: relative;
+  width: 155px;
 }
 
-.background-black {
-  background-color: #FFFFFF;
-  transition: all 0.3s ease;
-  color: #000000;
+.agent-photo {
+  width: 155px;
+  height: 155px;
+  object-fit: cover;
+  display: block;
+  filter: saturate(0.65) contrast(1.1);
+  transition: filter 0.4s;
+}
+body.background-black .agent-photo { filter: saturate(0.55) contrast(1.0) brightness(0.95); }
+
+.photo-scan {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent 0%, var(--orange) 40%, var(--orange-b) 50%, var(--orange) 60%, transparent 100%);
+  animation: scan-down 3.5s ease-in-out infinite;
+  opacity: 0.85;
+}
+@keyframes scan-down {
+  0%   { top: 0;     opacity: 1; }
+  75%  { opacity: 0.85; }
+  100% { top: 155px; opacity: 0; }
 }
 
-/* ── Lightbulb toggle ───────────────────────────────────────── */
-.lightbulb {
+.photo-badge {
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  background: rgba(229, 120, 32, 0.88);
+  color: var(--bg-0);
+  font-family: var(--f-mono);
+  font-size: 0.55rem;
+  letter-spacing: 0.14em;
+  text-align: center;
+  padding: 0.22rem;
+  font-weight: bold;
+}
+
+.gear-readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--orange-border);
+  background: var(--orange-dim);
+}
+.gear-readout .large { font-size: 1.15rem; line-height: 1; }
+
+/* ── Info column ─────────────────────────────────────────────── */
+.info-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.agent-name {
+  font-family: var(--f-display);
+  font-size: 3.6rem;
+  line-height: 0.95;
+  letter-spacing: 0.03em;
+  color: var(--text);
+  margin: 0.15rem 0 0.1rem;
+  transition: color 0.4s;
+}
+
+.status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.15rem;
+}
+.pulse-dot {
+  width: 7px; height: 7px;
+  background: var(--green);
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: pulse-g 2.5s ease-in-out infinite;
+}
+
+.divider {
+  height: 1px;
+  background: linear-gradient(90deg, var(--orange-border) 0%, transparent 100%);
+  margin: 0.8rem 0;
+}
+
+/* ── Link grid ───────────────────────────────────────────────── */
+.link-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.link-item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.32rem 0.55rem;
+  border: 1px solid var(--orange-border);
+  background: var(--orange-dim);
+  color: var(--dim);
+  text-decoration: none;
+  font-family: var(--f-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.07em;
+  transition: color 0.18s, border-color 0.18s, background 0.18s, box-shadow 0.18s;
+  cursor: crosshair;
+}
+.link-item:hover {
+  color: var(--orange);
+  border-color: var(--orange);
+  background: rgba(229, 120, 32, 0.18);
+  box-shadow: 0 0 10px rgba(229, 120, 32, 0.18);
+}
+
+/* ── Footer ──────────────────────────────────────────────────── */
+.hud-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.55rem 1.5rem;
+  border-top: 1px solid var(--orange-border);
+  background: var(--bg-1);
+  transition: background 0.4s, border-color 0.4s;
+}
+
+.mode-btn {
   background: none;
-  border: none;
-  color: inherit;
-  cursor: pointer;
+  border: 1px solid var(--orange-border);
+  color: var(--dim);
+  cursor: crosshair;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.28rem 0.6rem;
+  font-family: var(--f-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.07em;
+  transition: color 0.2s, border-color 0.2s;
 }
+.mode-btn:hover { color: var(--orange); border-color: var(--orange); }
+.mode-btn:focus-visible { outline: 1px solid var(--orange); outline-offset: 2px; }
 
-.lightbulb:focus {
-  outline: none;
+/* ── Responsive ──────────────────────────────────────────────── */
+@media (max-width: 500px) {
+  .card-inner { flex-direction: column; align-items: center; }
+  .photo-col  { align-items: center; width: 100%; }
+  .photo-frame, .agent-photo { width: 100%; height: auto; }
+  .agent-name { font-size: 3rem; }
+  .agent-card { padding: 1.25rem; }
+  .hud-footer { flex-wrap: wrap; gap: 0.4rem; }
 }
-
-.lightbulb:focus-visible {
-  outline: 2px solid currentColor;
-  border-radius: 4px;
-}
-
-.lightbulb:hover {
-  color: #FFD200;
-  transition: all 0.2s ease;
-}
-
-/* ── Profile photo ──────────────────────────────────────────── */
-.me-white {
-  box-shadow: 0px 24px 50px -15px rgba(255, 255, 255, 0.7);
-  border-radius: 50%;
-  height: 200px;
-  width: auto;
-  transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
-  user-select: none;
-}
-
-.me-white::after {
-  content: "";
-  border-radius: 5px;
-  position: absolute;
-  z-index: -1;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
-  opacity: 0;
-  transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
-}
-
-.me-white:hover { transform: scale(1.25, 1.25); }
-.me-white:hover::after { opacity: 1; }
-
-.me-black {
-  box-shadow: 0px 24px 50px -15px rgba(0, 0, 0, 0.6);
-  border-radius: 50%;
-  height: 200px;
-  width: auto;
-  transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
-  user-select: none;
-}
-
-.me-black::after {
-  content: "";
-  border-radius: 5px;
-  position: absolute;
-  z-index: -1;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
-  opacity: 0;
-  transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
-}
-
-.me-black:hover { transform: scale(1.25, 1.25); }
-.me-black:hover::after { opacity: 1; }


### PR DESCRIPTION
## Summary

- **Boot sequence** — On page load a full-screen SHD network initialisation screen appears (3.4 s): animated SHD logo with a slowly rotating dashed ring, five staggered typewriter lines in monospace, then Svelte `out:fade` / `in:fade` transitions into the main UI.
- **Agent profile card** — Photo with orange corner-bracket frame, horizontal scan-line animation, "IDENTITY VERIFIED" badge, Gear Score readout; name in Bebas Neue display font; green pulsing STATUS: ACTIVE indicator; tactical social-link buttons with orange hover glow.
- **HUD chrome** — Orange classification bar, fixed header with SHD icon + AGENT\_ONLINE pulse, footer with coordinates and NIGHT\_OPS / DAYLIGHT mode toggle.
- **Complete CSS rewrite** — Bebas Neue (display) / Rajdhani (body) / Share Tech Mono (all data readouts); `#E57820` SHD orange as sole accent; hex-grid SVG background via `body::before`; subtle scanline overlay; CSS-variable-driven daylight mode variant.
- **Font swap** — Drops locally-bundled Inter; loads Bebas Neue + Rajdhani + Share Tech Mono from Google Fonts via `app.html`.

## What a reviewer should know

This is a visual experiment / branch — it replaces the entire visual language of the site while preserving all existing functionality (photo, name, five social links, dark/light toggle, cookie persistence). The underlying Svelte 5 + SvelteKit static adapter setup is unchanged. Revert is a single `git revert` if the aesthetic direction doesn't ship.

## Test plan

- [ ] Visit `/` — boot sequence plays, transitions cleanly into the agent card
- [ ] All five social links open correct URLs in new tab
- [ ] NIGHT\_OPS / DAYLIGHT toggle switches between dark and light palettes; preference is persisted in cookie
- [ ] Resize to < 500 px — card stacks vertically, photo fills width
- [ ] `pnpm build` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)