### PR TITLE
Add company logo cards with hover tenure badges

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -59,24 +59,25 @@
       onclick={changeBackground}
       class="lightbulb float-left animated fadeIn p-2"
       aria-label="Toggle light/dark mode"
+      style="animation-delay: 0s"
     >
       <Icon icon={lightbulbIcon} width="2em" />
     </button>
   </div>
 
-  <div class="my-4 text-center align-middle">
-    <div class="me-size animated fadeIn">
+  <div class="my-4 text-center">
+    <div class="me-size animated fadeIn" style="animation-delay: 0.1s">
       <img
         src="/assets/me.jpg"
-        class="mx-auto d-block {lights ? 'me-white' : 'me-black'}"
+        class="mx-auto d-block me-photo"
         alt="paulogdm"
         draggable="false"
       >
     </div>
 
-    <div class="my-5 py-2 animated fadeIn">
+    <div class="my-5 py-2 animated fadeIn" style="animation-delay: 0.25s">
       <h1>paulogdm</h1>
-      <h6 class="mt-3" aria-label="Useful links">
+      <nav class="social-links mt-3" aria-label="Useful links">
         <a class="mx-2" href="&#77;&#97;&#73;&#76;&#84;&#79;&#58;&#109;&#101;&#64;&#112;&#97;&#117;&#108;&#111;&#103;&#100;&#109;&#46;&#99;&#111;&#109;" target="_blank" rel="noopener noreferrer" aria-label="Email">
           <Icon icon={mailIcon} width="1.33em" />
         </a>
@@ -95,7 +96,20 @@
         <a class="mx-2" href="https://cal.com/paulogdm/15min" target="_blank" rel="noopener noreferrer" aria-label="Schedule a time using cal.com">
           <Icon icon={calendarIcon} width="1.33em" />
         </a>
-      </h6>
+      </nav>
+    </div>
+  </div>
+
+  <div class="logo-row animated fadeIn" style="animation-delay: 0.45s">
+    <div class="logo-card" role="img" aria-label="Clerk" data-tenure="Since June 2026">
+      <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="m21.47 20.829-2.881-2.881a.572.572 0 0 0-.7-.084 6.854 6.854 0 0 1-7.081 0 .576.576 0 0 0-.7.084l-2.881 2.881a.576.576 0 0 0-.103.69.57.57 0 0 0 .166.186 12 12 0 0 0 14.113 0 .58.58 0 0 0 .239-.423.576.576 0 0 0-.172-.453Zm.002-17.668-2.88 2.88a.569.569 0 0 1-.701.084A6.857 6.857 0 0 0 8.724 8.08a6.862 6.862 0 0 0-1.222 3.692 6.86 6.86 0 0 0 .978 3.764.573.573 0 0 1-.083.699l-2.881 2.88a.567.567 0 0 1-.864-.063A11.993 11.993 0 0 1 6.771 2.7a11.99 11.99 0 0 1 14.637-.405.566.566 0 0 1 .232.418.57.57 0 0 1-.168.448Zm-7.118 12.261a3.427 3.427 0 1 0 0-6.854 3.427 3.427 0 0 0 0 6.854Z"/>
+      </svg>
+    </div>
+    <div class="logo-card" role="img" aria-label="Vercel" data-tenure="Nov 2018 to Feb 2026">
+      <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="m12 1.608 12 20.784H0Z"/>
+      </svg>
     </div>
   </div>
 </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -15,11 +15,10 @@ h1 {
   font-weight: 300;
   margin-top: 0;
   margin-bottom: 0.5rem;
-  transition: all 1s ease;
-  text-shadow: rgba(0,0,0,.01) 0 0 1px;
+  transition: color 1s ease;
 }
 
-h6 {
+.social-links {
   font-size: 1rem;
   font-weight: 300;
   margin-top: 0;
@@ -29,7 +28,7 @@ h6 {
 
 a {
   text-decoration: none;
-  transition: all 1s ease;
+  transition: color 0.3s ease;
   color: inherit;
 }
 
@@ -75,13 +74,13 @@ a:hover {
 /* ── Theme ──────────────────────────────────────────────────── */
 .background-white {
   background-color: #000000;
-  transition: all 0.3s ease;
+  transition: background-color 0.3s ease, color 0.3s ease;
   color: #FFFFFF;
 }
 
 .background-black {
   background-color: #FFFFFF;
-  transition: all 0.3s ease;
+  transition: background-color 0.3s ease, color 0.3s ease;
   color: #000000;
 }
 
@@ -105,6 +104,62 @@ a:hover {
 .lightbulb:hover {
   color: #FFD200;
   transition: all 0.2s ease;
+}
+
+/* ── Logo cards row ─────────────────────────────────────────── */
+.logo-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  padding: 0 1rem 3rem;
+}
+
+.logo-card {
+  width: 80px;
+  aspect-ratio: 1 / 1;
+  border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  position: relative;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), border-color 0.25s ease;
+  cursor: default;
+}
+
+.logo-card::after {
+  content: attr(data-tenure);
+  position: absolute;
+  bottom: -1.6rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  opacity: 0;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  color: #FF6600;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.logo-card:hover::after {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.logo-card:hover {
+  transform: scale(1.08);
+  border-color: #FF6600;
+}
+
+.logo-card svg,
+.logo-card img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
 }
 
 /* ── Profile photo ──────────────────────────────────────────── */
@@ -134,8 +189,7 @@ a:hover {
   transform: scaleX(0.45);
 }
 
-.me-white,
-.me-black {
+.me-photo {
   border-radius: 50%;
   height: 200px;
   width: auto;
@@ -143,7 +197,18 @@ a:hover {
   transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-.me-white:hover,
-.me-black:hover {
+.me-photo:hover {
   transform: scale(1.1);
+}
+
+/* ── Reduced motion ─────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .animated {
+    animation: none;
+  }
+
+  .me-photo:hover,
+  .logo-card:hover {
+    transform: none;
+  }
 }


### PR DESCRIPTION
## Summary

- Adds a centered row of square (1:1) logo cards below the social links, with inline SVGs for Clerk and Vercel that use `fill="currentColor"` — logos automatically invert with the light/dark theme toggle
- Hovering a card reveals a small orange tenure label below it via CSS `::after` + `data-tenure` attribute (no JS, no extra elements)
- Several housekeeping improvements discovered during the session:
  - `transition: all` → explicit properties on `a`, `h1`, and theme classes (avoids unnecessary repaints)
  - `<h6>` replaced with `<nav class="social-links">` for correct semantics
  - Duplicate `.me-white`/`.me-black` classes merged into single `.me-photo`
  - Orphaned `align-middle` class and invisible `text-shadow` on `h1` removed
  - Staggered `animation-delay` (0s → 0.1s → 0.25s → 0.45s) for a sequenced page entrance
  - `prefers-reduced-motion` media query added — disables animations and hover transforms for users who opted out

## Test plan

- [ ] Toggle light/dark mode — logos should flip black/white cleanly
- [ ] Hover Clerk card — "Since June 2026" fades in below in orange
- [ ] Hover Vercel card — "Nov 2018 to Feb 2026" fades in below in orange
- [ ] Verify page load entrance feels sequenced (lightbulb → photo → name → cards)
- [ ] Test with `prefers-reduced-motion: reduce` in browser DevTools — all animations and hover transforms should be disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)