### PR TITLE
Replace logo cards with horizontal career timeline

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -100,16 +100,37 @@
     </div>
   </div>
 
-  <div class="logo-row animated fadeIn" style="animation-delay: 0.45s">
-    <div class="logo-card" role="img" aria-label="Clerk" data-tenure="Since June 2026">
-      <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-        <path d="m21.47 20.829-2.881-2.881a.572.572 0 0 0-.7-.084 6.854 6.854 0 0 1-7.081 0 .576.576 0 0 0-.7.084l-2.881 2.881a.576.576 0 0 0-.103.69.57.57 0 0 0 .166.186 12 12 0 0 0 14.113 0 .58.58 0 0 0 .239-.423.576.576 0 0 0-.172-.453Zm.002-17.668-2.88 2.88a.569.569 0 0 1-.701.084A6.857 6.857 0 0 0 8.724 8.08a6.862 6.862 0 0 0-1.222 3.692 6.86 6.86 0 0 0 .978 3.764.573.573 0 0 1-.083.699l-2.881 2.88a.567.567 0 0 1-.864-.063A11.993 11.993 0 0 1 6.771 2.7a11.99 11.99 0 0 1 14.637-.405.566.566 0 0 1 .232.418.57.57 0 0 1-.168.448Zm-7.118 12.261a3.427 3.427 0 1 0 0-6.854 3.427 3.427 0 0 0 0 6.854Z"/>
-      </svg>
+  <section
+    class="tl-section animated fadeIn"
+    style="animation-delay: 0.45s"
+    aria-label="Career timeline: Vercel Nov 2018 to Feb 2026, Clerk since June 2026"
+  >
+    <div class="tl-wrap">
+      <div class="tl-labels" aria-hidden="true">
+        <div class="tl-company tl-clerk" data-tenure="Since June 2026">
+          <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="m21.47 20.829-2.881-2.881a.572.572 0 0 0-.7-.084 6.854 6.854 0 0 1-7.081 0 .576.576 0 0 0-.7.084l-2.881 2.881a.576.576 0 0 0-.103.69.57.57 0 0 0 .166.186 12 12 0 0 0 14.113 0 .58.58 0 0 0 .239-.423.576.576 0 0 0-.172-.453Zm.002-17.668-2.88 2.88a.569.569 0 0 1-.701.084A6.857 6.857 0 0 0 8.724 8.08a6.862 6.862 0 0 0-1.222 3.692 6.86 6.86 0 0 0 .978 3.764.573.573 0 0 1-.083.699l-2.881 2.88a.567.567 0 0 1-.864-.063A11.993 11.993 0 0 1 6.771 2.7a11.99 11.99 0 0 1 14.637-.405.566.566 0 0 1 .232.418.57.57 0 0 1-.168.448Zm-7.118 12.261a3.427 3.427 0 1 0 0-6.854 3.427 3.427 0 0 0 0 6.854Z"/>
+          </svg>
+          Clerk
+        </div>
+        <div class="tl-company tl-vercel" data-tenure="Nov 2018 to Feb 2026">
+          <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="m12 1.608 12 20.784H0Z"/>
+          </svg>
+          Vercel
+        </div>
+      </div>
+      <div class="tl-track" aria-hidden="true">
+        <span class="tl-spark"></span>
+        <span class="tl-vercel-seg"></span>
+      </div>
+      <div class="tl-years" aria-hidden="true">
+        <span class="tl-yr tl-yr-now">now</span>
+        <span class="tl-yr" style="left: 27%">'24</span>
+        <span class="tl-yr" style="left: 51%">'22</span>
+        <span class="tl-yr" style="left: 75%">'20</span>
+        <span class="tl-yr tl-yr-end">'18</span>
+      </div>
     </div>
-    <div class="logo-card" role="img" aria-label="Vercel" data-tenure="Nov 2018 to Feb 2026">
-      <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-        <path d="m12 1.608 12 20.784H0Z"/>
-      </svg>
-    </div>
-  </div>
+  </section>
 </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -106,37 +106,57 @@ a:hover {
   transition: all 0.2s ease;
 }
 
-/* ── Logo cards row ─────────────────────────────────────────── */
-.logo-row {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 1rem;
-  padding: 0 1rem 3rem;
+/* ── Career timeline ─────────────────────────────────────────── */
+.tl-section {
+  padding: 0 1.5rem 3rem;
 }
 
-.logo-card {
-  width: 80px;
-  aspect-ratio: 1 / 1;
-  border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
-  border-radius: 12px;
+.tl-wrap {
+  position: relative;
+  width: 100%;
+}
+
+/* Company labels above the track */
+.tl-labels {
+  position: relative;
+  height: 1.5rem;
+  margin-bottom: 0.65rem;
+}
+
+.tl-company {
+  position: absolute;
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 18px;
-  position: relative;
-  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), border-color 0.25s ease;
+  gap: 0.3rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
   cursor: default;
 }
 
-.logo-card::after {
+.tl-company svg {
+  width: 11px;
+  height: 11px;
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
+.tl-clerk  { left: 0; }
+
+.tl-vercel {
+  left: 49%;
+  transform: translateX(-50%);
+}
+
+/* Tenure badge — appears below each company label on hover */
+.tl-company::after {
   content: attr(data-tenure);
   position: absolute;
-  bottom: -1.6rem;
-  left: 50%;
-  transform: translateX(-50%) translateY(4px);
+  left: calc(100% + 0.4rem);
+  top: 50%;
+  transform: translateY(-50%) translateX(3px);
   opacity: 0;
-  font-size: 0.6rem;
+  font-size: 0.58rem;
   letter-spacing: 0.06em;
   white-space: nowrap;
   color: #FF6600;
@@ -144,22 +164,101 @@ a:hover {
   transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
-.logo-card:hover::after {
+.tl-company:hover::after {
   opacity: 1;
-  transform: translateX(-50%) translateY(0);
+  transform: translateY(-50%) translateX(0);
 }
 
-.logo-card:hover {
-  transform: scale(1.08);
-  border-color: #FF6600;
+/* The track line */
+.tl-track {
+  position: relative;
+  height: 1px;
+  background: color-mix(in srgb, currentColor 15%, transparent);
 }
 
-.logo-card svg,
-.logo-card img {
-  width: 100%;
+/* Vercel segment: Feb 2026 → Nov 2018 = 8% to 90% from left */
+.tl-vercel-seg {
+  position: absolute;
+  left: 8%;
+  width: 82%;
   height: 100%;
-  display: block;
-  object-fit: contain;
+  background: currentColor;
+  opacity: 0.5;
+}
+
+/* Tick marks at segment endpoints */
+.tl-vercel-seg::before,
+.tl-vercel-seg::after {
+  content: '';
+  position: absolute;
+  width: 1px;
+  height: 8px;
+  background: currentColor;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0.85;
+}
+.tl-vercel-seg::before { left: 0; }
+.tl-vercel-seg::after  { right: 0; }
+
+
+/* The "now" spark — small orange orb with double-halo */
+.tl-spark {
+  position: absolute;
+  left: -2px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #FF6600;
+  box-shadow: 0 0 4px 1px #FF6600, 0 0 10px 3px rgba(255, 102, 0, 0.25);
+}
+
+/* Two expanding halos — inset: -1.5px starts them at the original 7px diameter */
+.tl-spark::before,
+.tl-spark::after {
+  content: '';
+  position: absolute;
+  inset: -1.5px;
+  border-radius: 50%;
+  background: #FF6600;
+  animation: spark-halo 2.5s ease-out infinite;
+}
+.tl-spark::after { animation-delay: 1.25s; }
+
+@keyframes spark-halo {
+  0%   { transform: scale(1);   opacity: 0.45; }
+  100% { transform: scale(3.5); opacity: 0; }
+}
+
+/* Year markers below the track */
+.tl-years {
+  position: relative;
+  height: 1rem;
+  margin-top: 0.55rem;
+  user-select: none;
+}
+
+.tl-yr {
+  position: absolute;
+  font-size: 0.58rem;
+  letter-spacing: 0.07em;
+  opacity: 0.3;
+  transform: translateX(-50%);
+}
+
+.tl-yr-now {
+  left: 0;
+  transform: none;
+  opacity: 0.8;
+  color: #FF6600;
+}
+
+.tl-yr-end {
+  right: 0;
+  left: auto;
+  transform: none;
 }
 
 /* ── Profile photo ──────────────────────────────────────────── */
@@ -207,8 +306,12 @@ a:hover {
     animation: none;
   }
 
-  .me-photo:hover,
-  .logo-card:hover {
+  .me-photo:hover {
     transform: none;
+  }
+
+  .tl-spark::before,
+  .tl-spark::after {
+    animation: none;
   }
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -108,7 +108,7 @@ a:hover {
 
 /* ── Career timeline ─────────────────────────────────────────── */
 .tl-section {
-  padding: 0 1.5rem 3rem;
+  padding: 0 10% 3rem;
 }
 
 .tl-wrap {


### PR DESCRIPTION
## Summary

- Replaces the square logo card row with a minimal horizontal timeline (left = now, right = 2018)
- A dim 1px track carries a highlighted **Vercel segment** (Feb 2026 → Nov 2018) with tick marks at both endpoints
- **"now" spark**: a 4px orange orb at the left edge with a double-halo CSS animation — two filled rings expand outward from the same diameter, offset by 1.25s, giving a continuous pulsing effect without scale-jitter on the dot itself
- **Company labels** (Clerk + Vercel, with inline SVGs) float above the track; hovering either slides the tenure date in from the right via \`::after\` + \`data-tenure\` (CSS only, no JS)
- **Year markers** below: \`now\` in orange, then \`'24\`, \`'22\`, \`'20\`, \`'18\`
- \`prefers-reduced-motion\` disables the halo animations

## Implementation notes

- Halos use \`inset: -1.5px\` so they start at 7px diameter (the original orb size) regardless of the 4px orb — halo expansion distance stays consistent
- All colours via \`currentColor\` so the timeline adapts cleanly to the light/dark toggle
- No JS, no new dependencies

## Test plan

- [ ] Toggle light/dark mode — track, labels and year markers invert correctly
- [ ] Hover Clerk label → "Since June 2026" slides in from the right in orange
- [ ] Hover Vercel label → "Nov 2018 to Feb 2026" slides in from the right
- [ ] Open in browser (not screenshot) to confirm both halo rings animate continuously
- [ ] Enable \`prefers-reduced-motion\` in OS/DevTools — halos freeze, page-load fade-in still plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)