### PR TITLE
Make timeline positions dynamic based on current date

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -40,6 +40,38 @@
     }
   });
 
+  // ── Timeline math ────────────────────────────────────────────
+  // Right edge is fixed at Jan 2018. Left edge is "now", clamped
+  // to a minimum of May 24 2026 to guard against tampered clocks.
+  const tlStart  = new Date(2018, 0, 1);   // Jan 2018 — right edge
+  const tlMinNow = new Date(2026, 4, 24);  // May 24, 2026 — floor
+  const tlNow    = new Date() < tlMinNow ? tlMinNow : new Date();
+
+  const tlTotalMonths =
+    (tlNow.getFullYear() - tlStart.getFullYear()) * 12 +
+    (tlNow.getMonth()    - tlStart.getMonth());
+
+  // Percentage from the left (now) for any date on the timeline
+  function tlPct(date) {
+    const months =
+      (tlNow.getFullYear() - date.getFullYear()) * 12 +
+      (tlNow.getMonth()    - date.getMonth());
+    return +(Math.max(0, Math.min(100, months / tlTotalMonths * 100)).toFixed(3));
+  }
+
+  // Vercel: Nov 2018 → Feb 2026
+  const vercelEndDate   = new Date(2026,  1, 1);  // Feb 2026
+  const vercelStartDate = new Date(2018, 10, 1);  // Nov 2018
+  const vercelLeft      = tlPct(vercelEndDate);
+  const vercelWidth     = tlPct(vercelStartDate) - vercelLeft;
+  const vercelLabelLeft = vercelLeft + vercelWidth / 2;
+
+  // Year markers (positions only — '18 is always the right edge)
+  const tlYears = [2024, 2022, 2020].map(y => ({
+    label: `'${String(y).slice(2)}`,
+    left:  tlPct(new Date(y, 0, 1)),
+  }));
+
 </script>
 
 <svelte:head>
@@ -113,7 +145,7 @@
           </svg>
           Clerk
         </div>
-        <div class="tl-company tl-vercel" data-tenure="Nov 2018 to Feb 2026">
+        <div class="tl-company tl-vercel" data-tenure="Nov 2018 to Feb 2026" style="left: {vercelLabelLeft}%">
           <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
             <path d="m12 1.608 12 20.784H0Z"/>
           </svg>
@@ -122,13 +154,13 @@
       </div>
       <div class="tl-track" aria-hidden="true">
         <span class="tl-spark"></span>
-        <span class="tl-vercel-seg"></span>
+        <span class="tl-vercel-seg" style="left: {vercelLeft}%; width: {vercelWidth}%"></span>
       </div>
       <div class="tl-years" aria-hidden="true">
         <span class="tl-yr tl-yr-now">now</span>
-        <span class="tl-yr" style="left: 27%">'24</span>
-        <span class="tl-yr" style="left: 51%">'22</span>
-        <span class="tl-yr" style="left: 75%">'20</span>
+        {#each tlYears as { label, left }}
+          <span class="tl-yr" style="left: {left}%">{label}</span>
+        {/each}
         <span class="tl-yr tl-yr-end">'18</span>
       </div>
     </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -144,7 +144,6 @@ a:hover {
 .tl-clerk  { left: 0; }
 
 .tl-vercel {
-  left: 49%;
   transform: translateX(-50%);
 }
 
@@ -176,11 +175,9 @@ a:hover {
   background: color-mix(in srgb, currentColor 15%, transparent);
 }
 
-/* Vercel segment: Feb 2026 → Nov 2018 = 8% to 90% from left */
+/* Vercel segment — left/width set dynamically via inline style */
 .tl-vercel-seg {
   position: absolute;
-  left: 8%;
-  width: 82%;
   height: 100%;
   background: currentColor;
   opacity: 0.5;


### PR DESCRIPTION
## Summary

Replaces all hardcoded percentage positions on the career timeline with values computed at page load from the real current date.

- **Right edge** is fixed at Jan 2018 (the timeline start)
- **Left edge** is today's date, clamped to a minimum of **May 24 2026** to guard against tampered system clocks
- `tlPct(date)` converts any date to a `%` from the left using `months(date → now) / months(Jan 2018 → now)`, clamped to `[0, 100]`
- **Vercel segment** `left` and `width` are derived from `tlPct(Feb 2026)` and `tlPct(Nov 2018)` — as months pass, the segment compresses rightward without any manual updates
- **Vercel label** position tracks the segment center dynamically
- **Year markers** (`'24`, `'22`, `'20`) are generated from a mapped array using `tlPct`, so their positions drift correctly as the total span grows
- `'18` stays fixed at the right edge

## Test plan

- [ ] Verify segment and year positions look correct today (May 2026): Vercel ~3% left, ~87% wide; `'24` ~28%, `'22` ~52%, `'20` ~76%
- [ ] Simulate a future date (e.g. Jan 2028) by temporarily overriding `tlNow` in the script and confirm everything shifts proportionally
- [ ] Set system clock to a date before May 24 2026 — timeline should clamp to the minimum and not break

🤖 Generated with [Claude Code](https://claude.com/claude-code)