### PR TITLE
Add /agents.md — agent-friendly site representation

### DIFF
--- a/static/agents.md
+++ b/static/agents.md
@@ -1,0 +1,34 @@
+# paulogdm
+
+Personal page of Paulo G. De Mitri (paulogdm).
+
+## Identity
+
+- **Name:** Paulo G. De Mitri
+- **Handle:** paulogdm
+- **Email:** me@paulogdm.com
+
+## Contact & Social
+
+| Platform      | URL                                                              |
+|---------------|------------------------------------------------------------------|
+| Email         | me@paulogdm.com                                                  |
+| X / Twitter   | https://x.com/paulogdm                                           |
+| LinkedIn      | https://www.linkedin.com/in/paulogdm/                            |
+| GitHub        | https://github.com/paulogdm                                      |
+| Stack Overflow| https://stackoverflow.com/users/2665655/paulogdm                 |
+| Calendar      | https://cal.com/paulogdm/15min                                   |
+
+## Career Timeline
+
+- **Clerk**
+  - Senior Technical Account Manager (Jun 2026 → present)
+- **Vercel**
+  - Principal CSE (Feb 2025 → Jan 2026) — Owned the most complex customer issues at infrastructure depth, bridging GTM and Engineering.
+  - Software Engineer (May 2022 → Feb 2025) — Maintained DNS/domains systems and shipped public features like Vercel Data Cache and Custom Environments.
+  - Lead Customer Success Manager (Dec 2020 → Apr 2022) — First CSM at Vercel; helped grow the team in all regions, and onboard the first 100 Enterprise customers.
+  - Lead Customer Success Engineer (Nov 2018 → May 2020) — First support engineer at ~30 people; helped lay the foundation for the Customer Success org.
+
+## Job Opportunities
+
+To reach out about job opportunities, email jobs@paulogdm.com or schedule a call at https://cal.com/paulogdm/15min.


### PR DESCRIPTION
## What changed

Adds `static/agents.md`, served at `https://paulogdm.com/agents.md`.

## Why

AI agents and crawlers benefit from a structured, JavaScript-free Markdown version of the site. This file gives them a clean snapshot without needing to parse the Svelte app.

## Contents

- **Identity** — full name, handle, email
- **Contact & Social** — all links in plain text (email, X, LinkedIn, GitHub, Stack Overflow, Cal.com)
- **Career Timeline** — nested list by company, with per-role title, tenure, and one-liner description
- **Job Opportunities** — dedicated section pointing to jobs@paulogdm.com and the cal.com scheduling link

## Reviewer notes

No changes to the app itself — this is a purely additive static file. SvelteKit serves everything in `static/` as-is at the root path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)