### PR TITLE
Fix profile photo shadow rendering on Safari

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -285,13 +285,17 @@ a:hover {
   content: '';
   position: absolute;
   bottom: -8px;
-  left: 10%; right: 10%;
+  /* Width-based sizing replaces scaleX() — avoids the Safari bug where
+     filter:blur and transform interact incorrectly on the same element. */
+  left: 12%; right: 12%;
   height: 18px;
   border-radius: 50%;
   filter: blur(18px);
   opacity: 0.55;
-  transform: scaleX(0.85);
-  transition: opacity 0.5s ease, transform 0.5s ease;
+  /* translateZ(0) forces a compositor layer so Safari doesn't clip the
+     blur to the element's own bounding box. */
+  transform: translateZ(0);
+  transition: opacity 0.5s ease, left 0.5s ease, right 0.5s ease;
 }
 
 .background-white .me-size::after { background: rgba(255, 255, 255, 0.65); }
@@ -299,7 +303,7 @@ a:hover {
 
 .me-size:hover::after {
   opacity: 0.2;
-  transform: scaleX(0.45);
+  left: 30%; right: 30%;
 }
 
 .me-photo {


### PR DESCRIPTION
## Problem

The drop shadow beneath the profile photo rendered incorrectly on Safari — appearing clipped, sharp, or misaligned.

## Root cause (two compounding Safari bugs)

**1. `filter: blur()` clipped to bounding box on pseudo-elements**
Safari doesn't let blur paint outside an element's own box unless it's on a dedicated GPU compositor layer. With an `18px` blur on an `18px`-tall `::after`, the overflow was entirely clipped.

**Fix:** Added `transform: translateZ(0)` to force layer promotion.

**2. `transform` + `filter` render order conflict**
Safari applies `filter: blur()` and `transform` in the wrong order when both are set on the same element, causing the blur to appear unblurred or offset.

**Fix:** Replaced `scaleX(0.85)` with `left`/`right` percentage values to control width, so `transform` only carries `translateZ(0)` and the conflict is eliminated. The hover shrink effect is preserved via `left`/`right` transition instead.

## Test plan

- [ ] Verify shadow renders as a soft, diffuse ellipse on Safari (not clipped/sharp)
- [ ] Verify hover still fades and narrows the shadow on Safari and Chrome
- [ ] Verify light/dark mode shadow colors still apply correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)