### PR TITLE
Best practices cleanup: FOUC fix, CSS vars, naming, and misc

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -14,10 +14,19 @@
 
 <link rel="stylesheet" href="/styles.css">
 
+  <!-- Blocking theme script: reads cookie before first paint to prevent FOUC -->
+  <script>
+    (function () {
+      var m = document.cookie.match(/(^| )lights=([^;]+)/);
+      var dark = m ? m[2] === 'on' : window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.classList.add(dark ? 'theme-dark' : 'theme-light');
+    })();
+  </script>
+
   %sveltekit.head%
 </head>
 
-<body class="background-black" data-sveltekit-preload-data="hover">
+<body data-sveltekit-preload-data="hover">
   <div style="display: contents">%sveltekit.body%</div>
 </body>
 </html>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,8 +13,8 @@
   let lights = $state(false);
 
   $effect(() => {
-    document.body.classList.toggle('background-white', lights);
-    document.body.classList.toggle('background-black', !lights);
+    document.documentElement.classList.toggle('theme-dark', lights);
+    document.documentElement.classList.toggle('theme-light', !lights);
   });
 
   function getCookie(name) {
@@ -87,15 +87,14 @@
 </svelte:head>
 
 <div class="container">
-  <div class="px-4 py-4 clearfix">
+  <div class="px-4 py-4">
     <button
       onclick={changeBackground}
-      class="lightbulb float-left animated fadeIn p-2 {lights ? 'mode-dark' : 'mode-light'}"
+      class="lightbulb animated fadeIn p-2 {lights ? 'mode-dark' : 'mode-light'}"
       aria-label="Toggle light/dark mode"
-      style="animation-delay: 0s"
     >
       {#key lights}
-        <span class="icon-swap-e">
+        <span class="icon-swap">
           <Icon icon={lights ? sunIcon : moonIcon} width="2em" />
         </span>
       {/key}
@@ -114,7 +113,7 @@
 
     <div class="my-5 py-2 animated fadeIn" style="animation-delay: 0.25s">
       <h1>paulogdm</h1>
-      <nav class="social-links mt-3" aria-label="Useful links">
+      <nav class="social-links mt-3" aria-label="Social media and contact links">
         <a class="mx-2" href="&#77;&#97;&#73;&#76;&#84;&#79;&#58;&#109;&#101;&#64;&#112;&#97;&#117;&#108;&#111;&#103;&#100;&#109;&#46;&#99;&#111;&#109;" target="_blank" rel="noopener noreferrer" aria-label="Email">
           <Icon icon={mailIcon} width="1.33em" />
         </a>

--- a/static/styles.css
+++ b/static/styles.css
@@ -3,6 +3,26 @@
   box-sizing: border-box;
 }
 
+/* ── Design tokens ──────────────────────────────────────────── */
+:root {
+  --accent:      #FF6600;
+  --accent-glow: rgba(255, 102, 0, 0.25);
+  --accent-sun:  #FFD200;
+  --accent-moon: #0070F3;
+}
+
+html.theme-dark {
+  --bg:           #000000;
+  --text:         #FFFFFF;
+  --shadow-color: rgba(255, 255, 255, 0.65);
+}
+
+html.theme-light {
+  --bg:           #FFFFFF;
+  --text:         #000000;
+  --shadow-color: rgba(0, 0, 0, 0.4);
+}
+
 /* Fluid root: all rem-based sizes (spacing, icons, timeline labels) scale
    proportionally from 13px on narrow screens up to 16px at full width. */
 html {
@@ -14,6 +34,9 @@ body {
   font-family: 'Inter Variable', 'Inter', sans-serif;
   font-size: 1rem;
   line-height: 1.5;
+  background-color: var(--bg);
+  color: var(--text);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 h1 {
@@ -40,7 +63,7 @@ a {
 
 a:hover {
   text-decoration: none;
-  color: #FF6600;
+  color: var(--accent);
 }
 
 /* ── Bootstrap replacements ─────────────────────────────────── */
@@ -56,8 +79,6 @@ a:hover {
 .d-block     { display: block; }
 .text-center { text-align: center; }
 .mx-auto     { margin-left: auto; margin-right: auto; }
-.float-left  { float: left; }
-.clearfix::after { content: ""; display: table; clear: both; }
 
 .p-2  { padding: 0.5rem; }
 .px-4 { padding-left: 1.5rem; padding-right: 1.5rem; }
@@ -77,20 +98,7 @@ a:hover {
 .animated { animation-duration: 1s; animation-fill-mode: both; }
 .fadeIn   { animation-name: fadeIn; }
 
-/* ── Theme ──────────────────────────────────────────────────── */
-.background-white {
-  background-color: #000000;
-  transition: background-color 0.3s ease, color 0.3s ease;
-  color: #FFFFFF;
-}
-
-.background-black {
-  background-color: #FFFFFF;
-  transition: background-color 0.3s ease, color 0.3s ease;
-  color: #000000;
-}
-
-/* ── Lightbulb toggle ───────────────────────────────────────── */
+/* ── Theme toggle button ────────────────────────────────────── */
 .lightbulb {
   background: none;
   border: none;
@@ -108,19 +116,17 @@ a:hover {
 }
 
 /* Sun (dark mode) → yellow; Moon (light mode) → blue */
-.lightbulb.mode-dark:hover  { color: #FFD200; transition: color 0.2s ease; }
-.lightbulb.mode-light:hover { color: #0070F3; transition: color 0.2s ease; }
+.lightbulb.mode-dark:hover  { color: var(--accent-sun);  transition: color 0.2s ease; }
+.lightbulb.mode-light:hover { color: var(--accent-moon); transition: color 0.2s ease; }
 
 /* ── Icon swap animation — triggered by {#key} remount ─────── */
-
-/* E — blur dissolve */
-@keyframes icon-swap-e {
+@keyframes icon-swap {
   from { opacity: 0; filter: blur(6px); transform: scale(0.9); }
   to   { opacity: 1; filter: blur(0);   transform: scale(1);   }
 }
-.icon-swap-e {
+.icon-swap {
   display: inline-flex;
-  animation: icon-swap-e 0.3s ease-out both;
+  animation: icon-swap 0.3s ease-out both;
 }
 
 /* ── Career timeline ─────────────────────────────────────────── */
@@ -136,7 +142,7 @@ a:hover {
 /* Company labels above the track */
 .tl-labels {
   position: relative;
-  height: 1.5rem;
+  height: 2rem;
   margin-bottom: 1.1rem;
 }
 
@@ -175,7 +181,7 @@ a:hover {
   font-size: 1rem;
   letter-spacing: 0.06em;
   white-space: nowrap;
-  color: #FF6600;
+  color: var(--accent);
   pointer-events: none;
   transition: opacity 0.2s ease, transform 0.2s ease;
 }
@@ -225,8 +231,8 @@ a:hover {
   width: 4px;
   height: 4px;
   border-radius: 50%;
-  background: #FF6600;
-  box-shadow: 0 0 4px 1px #FF6600, 0 0 10px 3px rgba(255, 102, 0, 0.25);
+  background: var(--accent);
+  box-shadow: 0 0 4px 1px var(--accent), 0 0 10px 3px var(--accent-glow);
 }
 
 /* Two expanding halos — inset: -1.5px starts them at the original 7px diameter */
@@ -236,7 +242,7 @@ a:hover {
   position: absolute;
   inset: -1.5px;
   border-radius: 50%;
-  background: #FF6600;
+  background: var(--accent);
   animation: spark-halo 2.5s ease-out infinite;
 }
 .tl-spark::after { animation-delay: 1.25s; }
@@ -266,7 +272,7 @@ a:hover {
   left: 0;
   transform: none;
   opacity: 0.8;
-  color: #FF6600;
+  color: var(--accent);
 }
 
 .tl-yr-end {
@@ -284,22 +290,20 @@ a:hover {
 .me-size::after {
   content: '';
   position: absolute;
-  bottom: -8px;
+  bottom: -0.5em;
   /* Width-based sizing replaces scaleX() — avoids the Safari bug where
      filter:blur and transform interact incorrectly on the same element. */
   left: 12%; right: 12%;
   height: 1.125em;
   border-radius: 50%;
-  filter: blur(18px);
+  filter: blur(1.125em);
   opacity: 0.55;
+  background: var(--shadow-color);
   /* translateZ(0) forces a compositor layer so Safari doesn't clip the
      blur to the element's own bounding box. */
   transform: translateZ(0);
   transition: opacity 0.5s ease, left 0.5s ease, right 0.5s ease;
 }
-
-.background-white .me-size::after { background: rgba(255, 255, 255, 0.65); }
-.background-black .me-size::after { background: rgba(0, 0, 0, 0.4); }
 
 .me-size:hover::after {
   opacity: 0.2;
@@ -321,7 +325,7 @@ a:hover {
 /* ── Reduced motion ─────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .animated,
-  .icon-swap-e {
+  .icon-swap {
     animation: none;
   }
 


### PR DESCRIPTION
## Summary

Eleven improvements in one pass — all verified in preview.

| # | Fix | Change |
|---|-----|--------|
| 1 | **FOUC** | Blocking `<script>` in `<head>` reads the `lights` cookie and sets `theme-dark`/`theme-light` on `<html>` before first paint |
| 2 | **Class naming** | `background-white`/`background-black` → `theme-dark`/`theme-light`; `$effect` now targets `documentElement` |
| 4 | **meta description** | Already present in `app.html` ✓ |
| 5 | **CSS custom properties** | `--accent`, `--accent-glow`, `--accent-sun`, `--accent-moon`, `--bg`, `--text`, `--shadow-color` replace all hardcoded colors |
| 6 | **Float layout** | Removed `float-left` + `clearfix` from toggle button wrapper — button is naturally inline |
| 7 | **Shadow offset** | `bottom: -8px` → `bottom: -0.5em` |
| 8 | **Icon class name** | `icon-swap-e` → `icon-swap` |
| 9 | **Redundant delay** | Removed `animation-delay: 0s` from toggle button |
| 10 | **Label row height** | `.tl-labels` `1.5rem` → `2rem` to fit 1rem labels |
| 12 | **Social nav aria** | `"Useful links"` → `"Social media and contact links"` |
| 13 | **Shadow blur** | `blur(18px)` → `blur(1.125em)` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)