### PR TITLE
Add opaque background to tenure badge

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -187,6 +187,10 @@ a:hover {
   color: var(--accent);
   pointer-events: none;
   transition: opacity 0.2s ease, transform 0.2s ease;
+  padding: 0.15em 0.6em;
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--bg) 85%, transparent);
+  z-index: 10;
 }
 
 .tl-company:hover::after {


### PR DESCRIPTION
## Summary

- Adds `padding`, `border-radius`, `background`, and `z-index` to the `.tl-company::after` tenure badge
- Background uses `color-mix(in srgb, var(--bg) 85%, transparent)` so it works in both light and dark mode
- `z-index: 10` ensures the badge always renders on top of the Vercel label when they overlap

## Test plan
- [ ] Hover over "Clerk" label — tenure badge "now ← Jun '26" should be fully readable with no Vercel text bleeding through
- [ ] Toggle light/dark mode — background should match the page color in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)