### PR TITLE
Timeline hover interactions

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -194,6 +194,15 @@ a:hover {
   transform: translateY(-50%) translateX(0);
 }
 
+/* When any company is hovered, fade out the others */
+.tl-company {
+  transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.tl-labels:has(.tl-company:hover) .tl-company:not(:hover) {
+  opacity: 0;
+  transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 /* The track line */
 .tl-track {
   position: relative;

--- a/static/styles.css
+++ b/static/styles.css
@@ -203,6 +203,14 @@ a:hover {
   transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+/* Highlight the relevant timeline piece on hover */
+.tl-labels:has(.tl-vercel:hover) ~ .tl-track .tl-vercel-seg {
+  opacity: 1;
+}
+.tl-labels:has(.tl-clerk:hover) ~ .tl-track .tl-spark {
+  box-shadow: 0 0 8px 3px var(--accent), 0 0 22px 10px var(--accent-glow);
+}
+
 /* The track line */
 .tl-track {
   position: relative;
@@ -216,6 +224,8 @@ a:hover {
   height: 100%;
   background: currentColor;
   opacity: 0.5;
+  transition: background 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity   0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* Tick marks at segment endpoints */
@@ -245,6 +255,7 @@ a:hover {
   border-radius: 50%;
   background: var(--accent);
   box-shadow: 0 0 4px 1px var(--accent), 0 0 10px 3px var(--accent-glow);
+  transition: box-shadow 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* Two expanding halos — inset: -1.5px starts them at the original 7px diameter */


### PR DESCRIPTION
## Summary

- Hovering a company label fades out all others (0.4s smooth easing)
- Hovering Vercel brightens its timeline segment (opacity 0.5 → 1)
- Hovering Clerk intensifies the spark glow at the "now" position
- All purely CSS using `:has()` — no JS

## Test plan
- [ ] Hover Clerk → Vercel fades, spark glows brighter
- [ ] Hover Vercel → Clerk fades, segment bar brightens
- [ ] Mouse out → both restore smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)