### PR TITLE
Highlight now when hovering a company with a future start date

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -296,6 +296,11 @@ a:hover {
   transform: none;
   opacity: 0.8;
   color: var(--accent);
+  transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.tl-labels:has(.tl-clerk:hover) ~ .tl-years .tl-yr-now {
+  opacity: 1;
 }
 
 .tl-yr-end {


### PR DESCRIPTION
## Summary

- Hovering Clerk (start date Jun '26, still in the future) brings the "now" label to full opacity
- Smooth 0.4s transition on `.tl-yr-now`

## Test plan
- [ ] Hover Clerk → "now" label brightens
- [ ] Mouse out → "now" returns to its default opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)