### PR TITLE
Add drag-resistance effect to profile photo + fix shadow z-index

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,6 +12,49 @@
 
   let lights = $state(false);
 
+  // ── Photo drag resistance ────────────────────────────────────────────────────
+  let isDragging  = $state(false);
+  let photoX      = $state(0);
+  let photoY      = $state(0);
+  let dragOriginX = 0;
+  let dragOriginY = 0;
+
+  // tanh gives natural rubber-band feel: small pulls move freely, hard pulls
+  // hit a soft wall. Max visible displacement is ±MAX_PX regardless of drag.
+  const MAX_PX = 24;
+  const TENSION = 85; // lower = stiffer
+
+  function resist(v) {
+    return Math.tanh(v / TENSION) * MAX_PX;
+  }
+
+  function onPhotoDragStart(e) {
+    isDragging  = true;
+    dragOriginX = e.clientX;
+    dragOriginY = e.clientY;
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }
+
+  function onPhotoMove(e) {
+    if (!isDragging) return;
+    photoX = resist(e.clientX - dragOriginX);
+    photoY = resist(e.clientY - dragOriginY);
+  }
+
+  function onPhotoRelease() {
+    isDragging = false;
+    photoX = 0;
+    photoY = 0;
+  }
+
+  // Derived style — applied inline so transition can be toggled per-state
+  let photoStyle = $derived(
+    isDragging
+      ? `transform: translate(${photoX}px, ${photoY}px) perspective(500px) rotateX(${(-photoY * 0.55).toFixed(2)}deg) rotateY(${(photoX * 0.55).toFixed(2)}deg) scale(1.04); transition: transform 0s; cursor: grabbing;`
+      : 'cursor: grab;'
+  );
+  // ── End photo drag resistance ─────────────────────────────────────────────
+
   $effect(() => {
     document.documentElement.classList.toggle('theme-dark', lights);
     document.documentElement.classList.toggle('theme-light', !lights);
@@ -533,12 +576,17 @@
   </div>
 
   <div class="my-4 text-center">
-    <div class="me-size animated fadeIn" style="animation-delay: 0.1s">
+    <div class="me-size animated fadeIn" class:me-size--dragging={isDragging} style="animation-delay: 0.1s">
       <img
         src="/assets/me.jpg"
         class="mx-auto d-block me-photo"
         alt="paulogdm"
         draggable="false"
+        style={photoStyle}
+        onpointerdown={onPhotoDragStart}
+        onpointermove={onPhotoMove}
+        onpointerup={onPhotoRelease}
+        onpointercancel={onPhotoRelease}
       >
     </div>
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -347,6 +347,7 @@ a:hover {
   /* translateZ(0) forces a compositor layer so Safari doesn't clip the
      blur to the element's own bounding box. */
   transform: translateZ(0);
+  z-index: -1;
   transition: opacity 0.5s ease, left 0.5s ease, right 0.5s ease;
 }
 
@@ -355,12 +356,22 @@ a:hover {
   left: 30%; right: 30%;
 }
 
+/* Shadow reacts when the photo is grabbed — shrinks like it's lifting */
+.me-size--dragging::after {
+  opacity: 0.12 !important;
+  left: 38% !important;
+  right: 38% !important;
+  transition: opacity 0s, left 0s, right 0s;
+}
+
 .me-photo {
   border-radius: 50%;
   height: clamp(130px, 22vw, 200px);
   width: auto;
   user-select: none;
-  transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+  touch-action: none;
+  /* Spring-back when released */
+  transition: transform 0.55s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .me-photo:hover {
@@ -374,8 +385,9 @@ a:hover {
     animation: none;
   }
 
-  .me-photo:hover {
-    transform: none;
+  .me-photo:hover,
+  .me-photo[style] {
+    transform: none !important;
   }
 
   .tl-spark::before,


### PR DESCRIPTION
## What changed

**Drag resistance on the profile photo** — click and hold the photo and try to drag it. It stays anchored but pushes back with a rubber-band feel:

- Displacement uses `tanh(pull / 85) × 24px`: small movements feel free, hard pulls approach a soft ~24px wall asymptotically
- A subtle `perspective(500px) rotateX/Y` tilt adds tactile depth while dragging
- `setPointerCapture` keeps tracking even if the cursor leaves the element
- On release, the existing overshoot `cubic-bezier(0.34, 1.56, 0.64, 1)` springs it back
- `touch-action: none` prevents scroll conflicts on mobile
- `prefers-reduced-motion` block neutralises the inline transform

**Shadow z-index bug fix** (unrelated, noticed during the session) — the `::after` drop-shadow pseudo-element was painting *in front of* the photo due to paint order. Fixed with `z-index: -1`.

**Shadow drag feedback** — a new `.me-size--dragging` class shrinks and fades the shadow during drag, simulating the photo lifting off the surface.

## Test plan

- [ ] Click and hold the photo — cursor changes to `grabbing`
- [ ] Drag in any direction — photo follows with clear resistance, never moves more than ~24px
- [ ] Release — photo springs back with a slight overshoot bounce
- [ ] Verify shadow is visible *below* the photo (not overlaid on it)
- [ ] Check on mobile / touch — no page scroll triggered during drag
- [ ] Toggle `prefers-reduced-motion` in devtools — photo should not move at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)