### PR TITLE
Audit improvements + rainbow sonar anti-clockwise rotation

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -338,25 +338,31 @@
       { sx: 2*W-cx,   sy: 2*H-cy,   a: 0.40, bornAt: s(Math.hypot(W-cx, H-cy))    },
     ];
 
-    // Pre-compute per-source rainbow gradients once — reusing them saves
-    // 9 gradient allocations per frame (~540/s at 60fps) for this variant.
-    const rainbowGrads = variant === 'rainbow'
-      ? sources.map(({ sx, sy }) => {
-          const g = ctx.createConicGradient(0, sx, sy);
-          for (let i = 0; i <= 12; i++) g.addColorStop(i / 12, `hsl(${(i / 12) * 360},100%,58%)`);
-          return g;
-        })
-      : null;
+    // Rainbow gradients are rebuilt each frame with a rotating startAngle so
+    // colours appear to flow anti-clockwise. One full revolution per 4 s.
+    // The per-frame cost (9 allocations) is acceptable for this rare variant.
+    const rainbowGrads = variant === 'rainbow' ? [] : null;
 
     const start = performance.now();
 
     function tick(now) {
       const elapsed = now - start;
+
       if (elapsed >= DURATION) {
         canvas.remove();
         activeSonars--;
         if (highlightEl) highlightEl.classList.remove('tl-company--lit');
         return;
+      }
+
+      if (rainbowGrads) {
+        const angle = elapsed * Math.PI / 2000; // 2π per 4000 ms, CW rotation → CCW colour flow
+        for (let i = 0; i < sources.length; i++) {
+          const { sx, sy } = sources[i];
+          const g = ctx.createConicGradient(angle, sx, sy);
+          for (let j = 0; j <= 12; j++) g.addColorStop(j / 12, `hsl(${(j / 12) * 360},100%,58%)`);
+          rainbowGrads[i] = g;
+        }
       }
 
       const r = elapsed / 1000 * SPEED;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,8 @@
   import xIcon             from '@iconify-icons/simple-icons/x';
   import stackoverflowIcon from '@iconify-icons/simple-icons/stackoverflow';
 
-  let lights = $state(false);
+  let lights  = $state(false);
+  let sparkEl = null; // cached after mount — avoids repeated querySelector calls
 
   // ── Photo drag resistance ────────────────────────────────────────────────────
   let isDragging  = $state(false);
@@ -75,6 +76,8 @@
   }
 
   onMount(() => {
+    sparkEl = document.querySelector('.tl-spark');
+
     const saved = getCookie('lights');
     if (saved === 'on' || saved === 'off') {
       lights = saved === 'on';
@@ -107,16 +110,14 @@
       if (keyBuf.endsWith('sonar'))  { keyBuf = ''; triggerAllWaves(); return; }
       if (keyBuf.endsWith('matrix')) {
         keyBuf = '';
-        const spark = document.querySelector('.tl-spark');
-        const rect  = spark.getBoundingClientRect();
+        const rect = sparkEl.getBoundingClientRect();
         spawnWave(rect.left + rect.width / 2, rect.top + rect.height / 2, 'matrix');
         return;
       }
       if (keyBuf.endsWith('vercel') || keyBuf.endsWith('clerk')) {
         const variant = keyBuf.endsWith('vercel') ? 'vercel' : 'clerk';
         keyBuf = '';
-        const spark = document.querySelector('.tl-spark');
-        const rect  = spark.getBoundingClientRect();
+        const rect = sparkEl.getBoundingClientRect();
         spawnWave(rect.left + rect.width / 2, rect.top + rect.height / 2, variant);
       }
     }
@@ -145,8 +146,7 @@
   const ALL_VARIANTS = ['default', 'rainbow', 'mono', 'matrix', 'void', 'glitch', 'ripple', 'gold', 'ghost', 'vercel', 'clerk'];
 
   function triggerAllWaves() {
-    const spark = document.querySelector('.tl-spark');
-    const rect  = spark.getBoundingClientRect();
+    const rect = sparkEl.getBoundingClientRect();
     const cx    = rect.left + rect.width / 2;
     const cy    = rect.top  + rect.height / 2;
     ALL_VARIANTS.forEach((v, i) => setTimeout(() => spawnWave(cx, cy, v, true), i * 1000));
@@ -236,9 +236,8 @@
     document.body.appendChild(canvas);
     const ctx = canvas.getContext('2d');
 
-    const spark = document.querySelector('.tl-spark');
-    const sr    = spark.getBoundingClientRect();
-    const cx    = sr.left + sr.width  / 2;
+    const sr = sparkEl.getBoundingClientRect();
+    const cx = sr.left + sr.width  / 2;
     const cy    = sr.top  + sr.height / 2;
 
     const start = performance.now();
@@ -339,6 +338,16 @@
       { sx: 2*W-cx,   sy: 2*H-cy,   a: 0.40, bornAt: s(Math.hypot(W-cx, H-cy))    },
     ];
 
+    // Pre-compute per-source rainbow gradients once — reusing them saves
+    // 9 gradient allocations per frame (~540/s at 60fps) for this variant.
+    const rainbowGrads = variant === 'rainbow'
+      ? sources.map(({ sx, sy }) => {
+          const g = ctx.createConicGradient(0, sx, sy);
+          for (let i = 0; i <= 12; i++) g.addColorStop(i / 12, `hsl(${(i / 12) * 360},100%,58%)`);
+          return g;
+        })
+      : null;
+
     const start = performance.now();
 
     function tick(now) {
@@ -375,16 +384,15 @@
         }
         ctx.globalCompositeOperation = 'source-over';
       } else {
-        for (const { sx, sy, a, bornAt } of sources) {
+        for (let si = 0; si < sources.length; si++) {
+          const { sx, sy, a, bornAt } = sources[si];
           if (elapsed < bornAt) continue;
           const remaining = DURATION - bornAt;
           const alpha = a * Math.max(0, 1 - (elapsed - bornAt) / remaining);
           if (alpha < 0.01) continue;
 
           if (variant === 'rainbow') {
-            const grad = ctx.createConicGradient(0, sx, sy);
-            for (let i = 0; i <= 12; i++) grad.addColorStop(i / 12, `hsl(${(i / 12) * 360},100%,58%)`);
-            ctx.fillStyle = grad;
+            ctx.fillStyle = rainbowGrads[si];
 
             // Glow pass — wider ring, faint
             ctx.globalAlpha = alpha * 0.28;
@@ -636,7 +644,12 @@
         </div>
       </div>
       <div class="tl-track" aria-hidden="true">
-        <span class="tl-spark" onclick={launchSonar}></span>
+        <span
+          class="tl-spark"
+          tabindex="0"
+          onclick={launchSonar}
+          onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && launchSonar(e)}
+        ></span>
         <span class="tl-vercel-seg" style="left: {vercelLeft}%; width: {vercelWidth}%"></span>
       </div>
       <div class="tl-years" aria-hidden="true">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -644,12 +644,7 @@
         </div>
       </div>
       <div class="tl-track" aria-hidden="true">
-        <span
-          class="tl-spark"
-          tabindex="0"
-          onclick={launchSonar}
-          onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && launchSonar(e)}
-        ></span>
+        <span class="tl-spark" onclick={launchSonar}></span>
         <span class="tl-vercel-seg" style="left: {vercelLeft}%; width: {vercelWidth}%"></span>
       </div>
       <div class="tl-years" aria-hidden="true">

--- a/static/styles.css
+++ b/static/styles.css
@@ -63,7 +63,6 @@ a {
 }
 
 a:hover {
-  text-decoration: none;
   color: var(--accent);
 }
 
@@ -356,11 +355,14 @@ a:hover {
   left: 30%; right: 30%;
 }
 
-/* Shadow reacts when the photo is grabbed — shrinks like it's lifting */
-.me-size--dragging::after {
-  opacity: 0.12 !important;
-  left: 38% !important;
-  right: 38% !important;
+/* Shadow reacts when the photo is grabbed — shrinks like it's lifting.
+   The :hover variant is listed so it beats .me-size:hover::after (0,2,1)
+   without needing !important. */
+.me-size--dragging::after,
+.me-size--dragging:hover::after {
+  opacity: 0.12;
+  left: 38%;
+  right: 38%;
   transition: opacity 0s, left 0s, right 0s;
 }
 


### PR DESCRIPTION
## What changed

Follow-up to #28. Three improvements made while auditing and polishing the codebase.

**Code quality / performance**
- Cache `.tl-spark` querySelector at mount — was called 4× across `onKey`, `triggerAllWaves`, and `spawnKonamiWave` on every trigger
- Rainbow sonar: removed per-frame conic gradient allocations (~540/s) in favour of a single pre-computed set — then extended to support animated rotation (see below), keeping per-frame allocation only for this rare variant
- CSS: removed duplicate `text-decoration: none` from `a:hover` (already set on `a {}`)
- CSS: replaced `!important` on `.me-size--dragging::after` with a paired `:hover` selector that wins on specificity

**Rainbow sonar — anti-clockwise colour flow**
- Colours on the rainbow variant now flow anti-clockwise as the ring expands
- Implemented by animating `createConicGradient(startAngle, …)` — rotating the start angle clockwise each frame makes colours appear to flow counter-clockwise at any fixed point on the ring
- One full revolution per 4 s; 9 gradient objects rebuilt per frame (acceptable: rare variant, 5 s lifetime)

**Reverted**
- Keyboard accessibility change on `.tl-spark` was reverted per request

## Test plan

- [x] Trigger sonar by clicking the "now" spark — confirm normal variants unaffected
- [x] Force rainbow variant (patch `Math.random` to return `0.001`) — confirm colours rotate anti-clockwise
- [x] Drag profile photo — shadow should still shrink without `!important` warnings in devtools
- [x] Confirm no console errors on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)