### PR TITLE
Slow down Konami wave color cycling

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -256,7 +256,7 @@
       ctx.fillStyle = 'rgba(0,0,0,0.18)';
       for (let y = 0; y < H; y += 4) ctx.fillRect(0, y, W, 2);
 
-      if (frame % 2 === 0) colorIdx = (colorIdx + 1) % NES_COLORS.length;
+      if (frame % 10 === 0) colorIdx = (colorIdx + 1) % NES_COLORS.length;
       frame++;
 
       const r     = elapsed / 1000 * 220;


### PR DESCRIPTION
## What changed

Increased the color cycle interval in the Konami code easter egg from `frame % 2` to `frame % 10`.

## Why

At `frame % 2`, colors were cycling every ~33ms (~30 changes/sec at 60fps), which felt too fast and frantic. At `frame % 10`, they cycle every ~167ms (~6 changes/sec) — still vibrant, but much easier on the eyes.

## Files changed

- `src/routes/+page.svelte` — one-line change on line 259