### PR TITLE
Replace icon toggle with B&W pill flip switch

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -578,14 +578,21 @@
   <div class="px-4 py-4">
     <button
       onclick={changeBackground}
-      class="lightbulb animated fadeIn p-2 {lights ? 'mode-dark' : 'mode-light'}"
-      aria-label="Toggle light/dark mode"
+      class="theme-toggle animated fadeIn"
+      class:is-dark={lights}
+      role="switch"
+      aria-checked={lights}
+      aria-label={lights ? 'Switch to light mode' : 'Switch to dark mode'}
     >
-      {#key lights}
-        <span class="icon-swap">
-          <Icon icon={lights ? sunIcon : moonIcon} width="2em" />
+      <span class="tt-track">
+        <span class="tt-icon tt-icon--sun" aria-hidden="true">
+          <Icon icon={sunIcon} width="0.7rem" />
         </span>
-      {/key}
+        <span class="tt-icon tt-icon--moon" aria-hidden="true">
+          <Icon icon={moonIcon} width="0.7rem" />
+        </span>
+        <span class="tt-thumb"></span>
+      </span>
     </button>
   </div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,8 @@
   import xIcon             from '@iconify-icons/simple-icons/x';
   import stackoverflowIcon from '@iconify-icons/simple-icons/stackoverflow';
 
-  let lights  = $state(false);
+  let lights       = $state(false);
+  let coinRotation = $state(0);   // accumulates 180° per click — drives the coin flip
   let sparkEl = null; // cached after mount — avoids repeated querySelector calls
 
   // ── Photo drag resistance ────────────────────────────────────────────────────
@@ -72,6 +73,7 @@
 
   function changeBackground() {
     lights = !lights;
+    coinRotation += 180;
     setCookie('lights', lights ? 'on' : 'off');
   }
 
@@ -85,6 +87,7 @@
       lights = window.matchMedia('(prefers-color-scheme: dark)').matches;
       setCookie('lights', lights ? 'on' : 'off');
     }
+    coinRotation = lights ? 180 : 0;  // sync coin face with restored theme
 
     let keyBuf = '';
     const KONAMI_SEQ = ['arrowup','arrowup','arrowdown','arrowdown','arrowleft','arrowright','arrowleft','arrowright','b','a'];
@@ -578,21 +581,21 @@
   <div class="px-4 py-4">
     <button
       onclick={changeBackground}
-      class="theme-toggle animated fadeIn"
-      class:is-dark={lights}
+      class="coin-btn animated fadeIn"
       role="switch"
       aria-checked={lights}
       aria-label={lights ? 'Switch to light mode' : 'Switch to dark mode'}
     >
-      <span class="tt-track">
-        <span class="tt-icon tt-icon--sun" aria-hidden="true">
-          <Icon icon={sunIcon} width="0.7rem" />
-        </span>
-        <span class="tt-icon tt-icon--moon" aria-hidden="true">
-          <Icon icon={moonIcon} width="0.7rem" />
-        </span>
-        <span class="tt-thumb"></span>
-      </span>
+      <div class="coin-wrap">
+        <div class="coin" style="transform: perspective(160px) rotateY({coinRotation}deg)">
+          <div class="coin-face coin-front" aria-hidden="true">
+            <Icon icon={sunIcon} width="1.1rem" />
+          </div>
+          <div class="coin-face coin-back" aria-hidden="true">
+            <Icon icon={moonIcon} width="1.1rem" />
+          </div>
+        </div>
+      </div>
     </button>
   </div>
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -96,77 +96,62 @@ a:hover {
 .animated { animation-duration: 1s; animation-fill-mode: both; }
 .fadeIn   { animation-name: fadeIn; }
 
-/* ── Theme toggle (flip switch) ────────────────────────────── */
-.theme-toggle {
+/* ── Coin-flip theme toggle ────────────────────────────────── */
+.coin-btn {
   background: none;
   border: none;
-  padding: 0.375rem 0;
+  padding: 0.375rem;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  color: inherit;
-  user-select: none;
+  justify-content: center;
   -webkit-tap-highlight-color: transparent;
+  user-select: none;
 }
 
-.theme-toggle:focus { outline: none; }
-.theme-toggle:focus-visible .tt-track {
-  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--text);
+.coin-btn:focus        { outline: none; }
+.coin-btn:focus-visible { outline: 2px solid currentColor; border-radius: 50%; outline-offset: 3px; }
+
+/* Accent glow on hover — consistent with the rest of the site */
+.coin-wrap {
+  transition: filter 0.2s ease;
+}
+.coin-btn:hover .coin-wrap {
+  filter: drop-shadow(0 0 4px var(--accent));
 }
 
-/* Track: always filled with the text color so it contrasts the page */
-.tt-track {
+/* 3D container — perspective is inline so it moves with rotateY */
+.coin {
   position: relative;
-  display: block;
-  width: 3.25rem;        /* 52px @ 16px base */
-  height: 1.625rem;      /* 26px */
-  border-radius: 0.875rem;
-  background: var(--text);
-  transition: background 0.3s ease, box-shadow 0.2s ease;
+  width:  2.75rem;         /* 44px @ 16px base */
+  height: 2.75rem;
+  transform-style: preserve-3d;
+  transition: transform 0.55s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* Orange accent ring on hover — consistent with site accent */
-.theme-toggle:hover .tt-track {
-  box-shadow: 0 0 0 1.5px var(--accent);
-}
-
-/* Sun & moon icons — same color as bg so they hide under the thumb */
-.tt-icon {
+/* Shared face styles */
+.coin-face {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  inset: 0;
+  border-radius: 50%;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--bg);
-  pointer-events: none;
-  z-index: 1;
-  line-height: 0;
 }
 
-/* Icons centered at the thumb's resting positions:
-   thumb center (light) = gap(3px) + radius(10px) = 13px → icon left = 13 - icon_r(5.6) ≈ 7.5px
-   thumb center (dark)  = 52 - 13 = 39px           → icon right = 13 - 5.6 ≈ 7.5px       */
-.tt-icon--sun  { left:  0.47rem; }
-.tt-icon--moon { right: 0.47rem; }
-
-/* Thumb: page-background color, slides over whichever icon is active */
-.tt-thumb {
-  position: absolute;
-  top:  0.1875rem;       /* 3px gap all sides */
-  left: 0.1875rem;
-  width:  1.25rem;       /* 20px */
-  height: 1.25rem;
-  border-radius: 50%;
-  background: var(--bg);
-  z-index: 2;
-  /* travel = 52 - 20 - 3 - 3 = 26px = 1.625rem; spring overshoot */
-  transition: transform 0.4s cubic-bezier(0.34, 1.25, 0.64, 1);
+/* Front — black coin, white sun. Correct on a white (light-mode) page. */
+.coin-front {
+  background: #000000;
+  color: #ffffff;
 }
 
-/* Dark mode → thumb slides to cover the moon icon on the right */
-.theme-toggle.is-dark .tt-thumb {
-  transform: translateX(1.625rem);
+/* Back — white coin, black moon. Correct on a black (dark-mode) page. */
+.coin-back {
+  background: #ffffff;
+  color: #000000;
+  transform: rotateY(180deg);
 }
 
 /* ── Career timeline ─────────────────────────────────────────── */
@@ -426,7 +411,7 @@ a:hover {
     animation: none;
   }
 
-  .tt-thumb {
+  .coin {
     transition: none;
   }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -7,8 +7,6 @@
 :root {
   --accent:      #FF6600;
   --accent-glow: rgba(255, 102, 0, 0.25);
-  --accent-sun:  #FFD200;
-  --accent-moon: #0070F3;
 }
 
 html.theme-dark {
@@ -98,35 +96,77 @@ a:hover {
 .animated { animation-duration: 1s; animation-fill-mode: both; }
 .fadeIn   { animation-name: fadeIn; }
 
-/* ── Theme toggle button ────────────────────────────────────── */
-.lightbulb {
+/* ── Theme toggle (flip switch) ────────────────────────────── */
+.theme-toggle {
   background: none;
   border: none;
-  color: inherit;
+  padding: 0.375rem 0;
   cursor: pointer;
-}
-
-.lightbulb:focus {
-  outline: none;
-}
-
-.lightbulb:focus-visible {
-  outline: 2px solid currentColor;
-  border-radius: 4px;
-}
-
-/* Sun (dark mode) → yellow; Moon (light mode) → blue */
-.lightbulb.mode-dark:hover  { color: var(--accent-sun);  transition: color 0.2s ease; }
-.lightbulb.mode-light:hover { color: var(--accent-moon); transition: color 0.2s ease; }
-
-/* ── Icon swap animation — triggered by {#key} remount ─────── */
-@keyframes icon-swap {
-  from { opacity: 0; filter: blur(6px); transform: scale(0.9); }
-  to   { opacity: 1; filter: blur(0);   transform: scale(1);   }
-}
-.icon-swap {
   display: inline-flex;
-  animation: icon-swap 0.3s ease-out both;
+  align-items: center;
+  color: inherit;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.theme-toggle:focus { outline: none; }
+.theme-toggle:focus-visible .tt-track {
+  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--text);
+}
+
+/* Track: always filled with the text color so it contrasts the page */
+.tt-track {
+  position: relative;
+  display: block;
+  width: 3.25rem;        /* 52px @ 16px base */
+  height: 1.625rem;      /* 26px */
+  border-radius: 0.875rem;
+  background: var(--text);
+  transition: background 0.3s ease, box-shadow 0.2s ease;
+}
+
+/* Orange accent ring on hover — consistent with site accent */
+.theme-toggle:hover .tt-track {
+  box-shadow: 0 0 0 1.5px var(--accent);
+}
+
+/* Sun & moon icons — same color as bg so they hide under the thumb */
+.tt-icon {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--bg);
+  pointer-events: none;
+  z-index: 1;
+  line-height: 0;
+}
+
+/* Icons centered at the thumb's resting positions:
+   thumb center (light) = gap(3px) + radius(10px) = 13px → icon left = 13 - icon_r(5.6) ≈ 7.5px
+   thumb center (dark)  = 52 - 13 = 39px           → icon right = 13 - 5.6 ≈ 7.5px       */
+.tt-icon--sun  { left:  0.47rem; }
+.tt-icon--moon { right: 0.47rem; }
+
+/* Thumb: page-background color, slides over whichever icon is active */
+.tt-thumb {
+  position: absolute;
+  top:  0.1875rem;       /* 3px gap all sides */
+  left: 0.1875rem;
+  width:  1.25rem;       /* 20px */
+  height: 1.25rem;
+  border-radius: 50%;
+  background: var(--bg);
+  z-index: 2;
+  /* travel = 52 - 20 - 3 - 3 = 26px = 1.625rem; spring overshoot */
+  transition: transform 0.4s cubic-bezier(0.34, 1.25, 0.64, 1);
+}
+
+/* Dark mode → thumb slides to cover the moon icon on the right */
+.theme-toggle.is-dark .tt-thumb {
+  transform: translateX(1.625rem);
 }
 
 /* ── Career timeline ─────────────────────────────────────────── */
@@ -382,9 +422,12 @@ a:hover {
 
 /* ── Reduced motion ─────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
-  .animated,
-  .icon-swap {
+  .animated {
     animation: none;
+  }
+
+  .tt-thumb {
+    transition: none;
   }
 
   .me-photo:hover,


### PR DESCRIPTION
## What changed

Replaces the single sun/moon icon button with a sliding pill flip switch, inspired by the classic iOS-style toggle but stripped down to pure black-and-white geometry that fits the site's minimalist aesthetic.

## Design

- **Track** fills with `var(--text)` — always contrasts the page background (white on dark, black on light)
- **Thumb** is a circle in `var(--bg)` — same color as the page, so it appears to "punch out" of the track as it slides
- **Sun icon** anchored on the left (light mode active), **moon icon** on the right (dark mode active) — both rendered in `var(--bg)`, so the active icon disappears under the thumb and the inactive one is visible against the track
- **Hover** shows the site's orange accent ring (`var(--accent)`) around the track
- **Thumb animation** uses `cubic-bezier(0.34, 1.25, 0.64, 1)` for a subtle spring overshoot on slide
- Slide transition is disabled under `prefers-reduced-motion`
- `role="switch"` + `aria-checked` for proper accessibility semantics

## Files changed

- `src/routes/+page.svelte` — replaces the `lightbulb` button with new `theme-toggle` markup
- `static/styles.css` — removes `.lightbulb`, `.icon-swap` and unused `--accent-sun`/`--accent-moon` variables; adds `.theme-toggle`, `.tt-track`, `.tt-thumb`, `.tt-icon` styles