### PR TITLE
Image LCP/LQIP, canvas tab-pause & resize fixes, theme-aware Vercel wave, SEO cleanup

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Paulogdm personal page. Make yourself at home. Twitter, GitHub and StackOverflow profiles.">
-  <meta name="keywords" content="paulogdm,paulo mitri, paulogdemitri, paulo de mitri">
   <meta name="author" content="paulogdm">
 
   <link rel="icon" href="/assets/favicon-32.png" sizes="32x32" type="image/png">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -457,15 +457,18 @@
         // Expanding equilateral triangle — matches Vercel's ▲ logo orientation.
         // r is the circumradius (center → vertex), same scale as the circle waves.
         const h = r * Math.sqrt(3) / 2;  // half-width at base
+        // White ▲ on dark, black ▲ on light. Read the theme live so a mid-wave
+        // toggle recolours correctly (same approach as the mono variant).
+        const rgb = document.documentElement.classList.contains('theme-dark') ? '255,255,255' : '0,0,0';
         ctx.beginPath();
         ctx.moveTo(sx,     sy - r);       // top vertex
         ctx.lineTo(sx + h, sy + r / 2);   // bottom-right
         ctx.lineTo(sx - h, sy + r / 2);   // bottom-left
         ctx.closePath();
-        ctx.strokeStyle = `rgba(255,255,255,${alpha.toFixed(3)})`;
+        ctx.strokeStyle = `rgba(${rgb},${alpha.toFixed(3)})`;
         ctx.lineWidth   = 2;
         ctx.shadowBlur  = 20;
-        ctx.shadowColor = `rgba(255,255,255,${(alpha * 0.6).toFixed(3)})`;
+        ctx.shadowColor = `rgba(${rgb},${(alpha * 0.6).toFixed(3)})`;
         ctx.stroke();
         ctx.shadowBlur  = 0;
         ctx.shadowColor = 'transparent';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -139,11 +139,12 @@
   // cost, which fights the perf goals above. 2× is the sharpness/perf sweet spot.
   const DPR_CAP = 2;
 
-  let fxCanvas = null;
-  let fxCtx    = null;
-  let fxRaf    = 0;
-  let fxW      = 0;
-  let fxH      = 0;
+  let fxCanvas    = null;
+  let fxCtx       = null;
+  let fxRaf       = 0;
+  let fxResizeRaf = 0;
+  let fxW         = 0;
+  let fxH         = 0;
   const effects = []; // active effects: { startedAt, duration, render, onEnd?, onResize? }
 
   function fxResize() {
@@ -159,6 +160,17 @@
     for (const fx of effects) fx.onResize?.(fxW, fxH); // 13: let effects rebuild geometry
   }
 
+  // 17: a resize burst (dragging a window edge) fires dozens of events; each
+  // fxResize rebuilds the matrix/konami offscreen buffers and typed arrays.
+  // Coalesce to one rebuild per animation frame.
+  function scheduleResize() {
+    if (fxResizeRaf) return;
+    fxResizeRaf = requestAnimationFrame(() => {
+      fxResizeRaf = 0;
+      fxResize();
+    });
+  }
+
   function ensureCanvas() {
     if (fxCanvas) return;
     fxCanvas = document.createElement('canvas');
@@ -166,15 +178,17 @@
     fxCtx = fxCanvas.getContext('2d');
     document.body.appendChild(fxCanvas);
     fxResize();
-    window.addEventListener('resize', fxResize);
+    window.addEventListener('resize', scheduleResize);
   }
 
   function stopRenderer() {
     if (fxRaf) cancelAnimationFrame(fxRaf);
+    if (fxResizeRaf) cancelAnimationFrame(fxResizeRaf);
     fxRaf = 0;
+    fxResizeRaf = 0;
     effects.length = 0;
     if (fxCanvas) {
-      window.removeEventListener('resize', fxResize);
+      window.removeEventListener('resize', scheduleResize);
       fxCanvas.remove();
       fxCanvas = null;
       fxCtx = null;
@@ -295,7 +309,6 @@
     const SPEED   = variant === 'matrix' ? 440
                   : variant === 'vercel' ? 260
                   : 220;
-    const isDark  = document.documentElement.classList.contains('theme-dark');
 
     if (variant === 'matrix') addMatrixEffect();
 
@@ -320,12 +333,12 @@
         if (highlightEl) highlightEl.classList.remove('tl-company--lit');
       },
       render(ctx, elapsed) {
-        drawWave(ctx, elapsed, variant, SPEED, isDark, sources, rainbowGrads);
+        drawWave(ctx, elapsed, variant, SPEED, sources, rainbowGrads);
       },
     });
   }
 
-  function drawWave(ctx, elapsed, variant, SPEED, isDark, sources, rainbowGrads) {
+  function drawWave(ctx, elapsed, variant, SPEED, sources, rainbowGrads) {
     const W = fxW, H = fxH;
     const r = elapsed / 1000 * SPEED;
 
@@ -453,7 +466,8 @@
 
       let color, lineWidth;
       if (variant === 'mono') {
-        const rgb = isDark ? '255,255,255' : '0,0,0';
+        // Read the theme live so a mid-wave toggle recolours correctly (#18).
+        const rgb = document.documentElement.classList.contains('theme-dark') ? '255,255,255' : '0,0,0';
         color     = `rgba(${rgb},${alpha.toFixed(3)})`;
         lineWidth = 1;
         ctx.shadowBlur = 0; ctx.shadowColor = 'transparent';
@@ -725,7 +739,11 @@
         src="/assets/me.jpg"
         class="mx-auto d-block me-photo"
         alt="paulogdm"
+        width="500"
+        height="500"
         draggable="false"
+        fetchpriority="low"
+        decoding="async"
         style={photoStyle}
         onpointerdown={onPhotoDragStart}
         onpointermove={onPhotoMove}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -139,13 +139,13 @@
   // cost, which fights the perf goals above. 2× is the sharpness/perf sweet spot.
   const DPR_CAP = 2;
 
-  let fxCanvas    = null;
-  let fxCtx       = null;
-  let fxRaf       = 0;
-  let fxResizeRaf = 0;
-  let fxPausedAt  = 0; // performance.now() when the tab was hidden; 0 = running
-  let fxW         = 0;
-  let fxH         = 0;
+  let fxCanvas        = null;
+  let fxCtx           = null;
+  let fxRaf           = 0;
+  let fxResizePending = false;
+  let fxPausedAt      = 0; // performance.now() when the tab was hidden; 0 = running
+  let fxW             = 0;
+  let fxH             = 0;
   const effects = []; // active effects: { startedAt, duration, render, onEnd?, onResize? }
 
   function fxResize() {
@@ -163,13 +163,15 @@
 
   // 17: a resize burst (dragging a window edge) fires dozens of events; each
   // fxResize rebuilds the matrix/konami offscreen buffers and typed arrays.
-  // Coalesce to one rebuild per animation frame.
+  // Just flag it — fxTick applies the resize at the top of the next frame, so
+  // the canvas-clearing resize and the redraw happen in the same frame and in
+  // that order. Doing the resize in a *separate* rAF could land after the
+  // frame's draw, leaving a blank canvas for one frame (visible flash).
   function scheduleResize() {
-    if (fxResizeRaf) return;
-    fxResizeRaf = requestAnimationFrame(() => {
-      fxResizeRaf = 0;
-      fxResize();
-    });
+    fxResizePending = true;
+    // Ensure a frame runs to apply it — but not while paused (hidden tab),
+    // where onVisibility owns restarting the loop.
+    if (!fxRaf && !fxPausedAt) fxRaf = requestAnimationFrame(fxTick);
   }
 
   // 9: effects measure progress as (now - startedAt) on the wall clock. While a
@@ -202,9 +204,8 @@
 
   function stopRenderer() {
     if (fxRaf) cancelAnimationFrame(fxRaf);
-    if (fxResizeRaf) cancelAnimationFrame(fxResizeRaf);
     fxRaf = 0;
-    fxResizeRaf = 0;
+    fxResizePending = false;
     fxPausedAt = 0;
     effects.length = 0;
     if (fxCanvas) {
@@ -224,6 +225,14 @@
 
   function fxTick(now) {
     fxRaf = 0;
+
+    // Apply any pending resize first, in the same frame as the redraw below.
+    // (Resizing the backing store clears it, so the draw must follow it here.)
+    if (fxResizePending) {
+      fxResizePending = false;
+      fxResize();
+    }
+
     fxCtx.clearRect(0, 0, fxW, fxH); // single clear for the whole frame
 
     // Draw oldest → newest so freshly triggered effects layer on top.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -143,6 +143,7 @@
   let fxCtx       = null;
   let fxRaf       = 0;
   let fxResizeRaf = 0;
+  let fxPausedAt  = 0; // performance.now() when the tab was hidden; 0 = running
   let fxW         = 0;
   let fxH         = 0;
   const effects = []; // active effects: { startedAt, duration, render, onEnd?, onResize? }
@@ -171,6 +172,23 @@
     });
   }
 
+  // 9: effects measure progress as (now - startedAt) on the wall clock. While a
+  // tab is hidden, rAF stops firing but the clock keeps running — so on return
+  // an effect would jump ahead (or have silently expired). Pause by cancelling
+  // the loop on hide, and on show shift every startedAt forward by the hidden
+  // duration so accumulated elapsed is preserved and playback resumes in place.
+  function onVisibility() {
+    if (document.hidden) {
+      if (fxRaf) { cancelAnimationFrame(fxRaf); fxRaf = 0; }
+      fxPausedAt = performance.now();
+    } else if (fxPausedAt) {
+      const hiddenFor = performance.now() - fxPausedAt;
+      fxPausedAt = 0;
+      for (const fx of effects) fx.startedAt += hiddenFor;
+      if (effects.length && !fxRaf) fxRaf = requestAnimationFrame(fxTick);
+    }
+  }
+
   function ensureCanvas() {
     if (fxCanvas) return;
     fxCanvas = document.createElement('canvas');
@@ -179,6 +197,7 @@
     document.body.appendChild(fxCanvas);
     fxResize();
     window.addEventListener('resize', scheduleResize);
+    document.addEventListener('visibilitychange', onVisibility);
   }
 
   function stopRenderer() {
@@ -186,9 +205,11 @@
     if (fxResizeRaf) cancelAnimationFrame(fxResizeRaf);
     fxRaf = 0;
     fxResizeRaf = 0;
+    fxPausedAt = 0;
     effects.length = 0;
     if (fxCanvas) {
       window.removeEventListener('resize', scheduleResize);
+      document.removeEventListener('visibilitychange', onVisibility);
       fxCanvas.remove();
       fxCanvas = null;
       fxCtx = null;

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,7 @@
 User-agent: *
 Allow: /
 
+# Structured info for LLM/agent crawlers
+# https://paulogdm.com/agents.md
+
 Sitemap: https://paulogdm.com/sitemap.xml

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://paulogdm.com/</loc>
+    <lastmod>2026-05-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/static/styles.css
+++ b/static/styles.css
@@ -31,7 +31,7 @@ html {
 
 body {
   margin: 0;
-  font-family: 'Inter Variable', 'Inter', sans-serif;
+  font-family: 'Inter Variable', sans-serif;
   font-size: 1rem;
   line-height: 1.5;
   background-color: var(--bg);
@@ -268,8 +268,7 @@ a:hover {
 /* Sonar wave easter egg canvas */
 .sonar-canvas {
   position: fixed;
-  top: 0;
-  left: 0;
+  inset: 0; /* pin to viewport origin — the canvas is appended at end of <body> */
   pointer-events: none;
   z-index: 9999;
 }
@@ -370,10 +369,17 @@ a:hover {
   border-radius: 50%;
   height: clamp(130px, 22vw, 200px);
   width: auto;
+  aspect-ratio: 1 / 1; /* reserve space before the 500×500 photo decodes — avoids CLS */
   user-select: none;
   touch-action: none;
   /* Spring-back when released */
   transition: transform 0.55s cubic-bezier(0.34, 1.56, 0.64, 1);
+  /* LQIP: a ~1KB 24px blur of the photo, inlined (no extra request). Shows
+     instantly and is covered once the full me.jpg paints over it. background-size
+     cover + the matching border-radius keep it aligned with the round frame. */
+  background-image: url('data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD/4QBARXhpZgAATU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAAqACAAQAAAABAAAAGKADAAQAAAABAAAAGAAAAAD/7QA4UGhvdG9zaG9wIDMuMAA4QklNBAQAAAAAAAA4QklNBCUAAAAAABDUHYzZjwCyBOmACZjs+EJ+/8AAEQgAGAAYAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/bAEMABAQEBAQECAQECAsICAgLDwsLCwsPEg8PDw8PEhYSEhISEhIWFhYWFhYWFhsbGxsbGx8fHx8fIyMjIyMjIyMjI//bAEMBBQYGCQgJDwgIDyQZFBkkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJP/dAAQAAv/aAAwDAQACEQMRAD8A87j0sKm4jpVnXfh14l022j1qXU7cRSDPkrHuAyMqCx6n1ruIbWNMO4yq8n0x3qP4k6f4YtfJv9yGGaF3jVW+8zFWBPtjiuLGVJw5eV2PWwNGFTm51seApENR06K/C7S+cjtkEg4PpkVW+wV232W3i0uFbTBiKblK9MNzx+dZXle1di1SbPPkkm0j/9D5I1nXte1+Xz7u5cqR90EhQD2CjirOv+NvEPiTSrPR7mOJI7OFYdyj55Ng2gsx9scCsaL/AI9x/uj+VQp1P1NE4Rk02jKnVnFSSe5a0vxJqmjRrbBzLbg8xtyP+Ant/Ktz/hPov+fY/wDfX/1q4Wf/AFZ+v9KzqRabsf/Z');
+  background-size: cover;
+  background-position: center;
 }
 
 .me-photo:hover {


### PR DESCRIPTION
Continues the audit work from a fresh master. A mix of performance, robustness, and SEO/cleanup items, plus two follow-up fixes found while testing.

## What changed

### Profile photo — LCP & CLS (`02ec99e`)
- `width`/`height` (500×500) + `aspect-ratio: 1/1` reserve layout space before decode → removes CLS.
- `fetchpriority="low"` + `decoding="async"` — the photo is **intentionally not prioritized** (per request).
- Inline **~1KB LQIP** (24px blur of the photo, EXIF/ICC stripped) as a CSS `background-image` — a blurred preview shows instantly with **no extra request**, covered once `me.jpg` paints.

### Canvas easter eggs
- **Live theme for `mono`** (`02ec99e`): reads the theme each frame so a mid-wave light/dark toggle recolours correctly.
- **Resize coalescing** (`02ec99e`): a drag-resize burst was rebuilding the matrix/konami buffers dozens of times; now collapses to one rebuild per frame.
- **Pause on hidden tab** (`96be571`): effects track progress on the wall clock, so a backgrounded tab made them jump ahead / expire on return. A `visibilitychange` handler cancels the loop on hide and shifts each effect's `startedAt` forward by the hidden duration on show, resuming exactly in place.
- **Resize-flash fix** (`b94afc9`): *regression from the resize-coalescing change above.* `fxResize` ran in its own rAF separate from the draw loop; since resizing clears the canvas and the two callbacks' order within a frame isn't guaranteed, the frame could end blank → strobing during continuous resize. Folded the resize into the single render loop (event sets a flag, `fxTick` applies it at the top of the frame, immediately before clear+draw), so a blank frame is structurally impossible. Coalescing preserved.
- **Theme-aware Vercel wave** (`7b6b90c`): the ▲ was hard-coded white and invisible on the light theme. Now white on dark / black on light, read live each frame for mid-wave toggles.

### SEO / cleanup (`83cf4ba`)
- Remove `<meta name="keywords">` (ignored by all major search engines).
- Drop the dead `'Inter'` fallback token from the body font stack (only `'Inter Variable'` is defined).
- Add `<lastmod>` to `sitemap.xml` (the one directive Google still honours).
- Reference `/agents.md` from `robots.txt` so agent crawlers can discover it.
- `.sonar-canvas`: `top/left` → `inset:0` (cosmetic; equivalent).

## Verification (headless Chrome / CDP, against the production build)
- Photo: LQIP background present, decodes at 500px, `fetchpriority=low`, `aspect-ratio` applied.
- Easter eggs: spark click works; `mono` + mid-wave theme toggle → no error; idle teardown → 0 canvases; **0 JS errors**.
- Tab-pause: a konami wave survives a 3s hidden period without premature expiry, resumes, completes normally.
- Resize-flash: **302 frames** of continuous resize during a live wave → **0 blank frames**, 0 errors.
- Vercel wave: triangle pixels all-white on dark, all-black on light, recolour to white on toggle-to-dark mid-wave.

## Reviewer notes
- **OG image (#7) intentionally untouched** — the 88KB PNG from #34 is already optimized and crawler-safe.
- A few audit items were left as intentional by the owner (spark keyboard-a11y, year-marker contrast, `mailto` rel, reduced-motion-blocks-eggs) and are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)