### PR TITLE
Branded, theme-aware 404 page

### DIFF
--- a/src/lib/ErrorScreen.svelte
+++ b/src/lib/ErrorScreen.svelte
@@ -1,0 +1,87 @@
+<script>
+  // Shared branded error UI. Used by the prerendered /404 page (static hosts
+  // serve build/404.html for unknown URLs) and by +error.svelte for any
+  // runtime error inside the app.
+  let { status = 404, message = '' } = $props();
+
+  // 404 gets bespoke copy nodding to the site's "make yourself at home" line;
+  // anything else shows a generic message plus the real error text if present.
+  let isNotFound = $derived(status === 404);
+  let headline   = $derived(isNotFound ? "This page isn't home." : 'Something went sideways.');
+  let detail     = $derived(
+    isNotFound
+      ? "The page you're after doesn't exist — or it packed up and moved."
+      : (message || 'An unexpected error occurred.')
+  );
+</script>
+
+<main class="err">
+  <p class="code animated fadeIn">{status}</p>
+  <h1 class="headline animated fadeIn" style="animation-delay: 0.1s">{headline}</h1>
+  <p class="sub animated fadeIn" style="animation-delay: 0.2s">{detail}</p>
+
+  <a class="cta animated fadeIn" href="/" style="animation-delay: 0.3s">
+    Make yourself at home
+    <span class="arrow" aria-hidden="true">→</span>
+  </a>
+</main>
+
+<style>
+  .err {
+    /* Force Inter for everything here. The headline is an <h1>, and the global
+       stylesheet sets h1 { font-family: 'Syne' } — an element rule that beats
+       inheritance — so .headline below also sets it explicitly to win on
+       specificity. */
+    font-family: 'Inter Variable', sans-serif;
+    min-height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 2rem 1.5rem;
+  }
+
+  .code {
+    font-weight: 600;
+    font-size: clamp(4.5rem, 18vw, 9rem);
+    line-height: 0.95;
+    margin: 0;
+  }
+
+  .headline {
+    font-family: 'Inter Variable', sans-serif; /* override global h1 { Syne } */
+    font-weight: 500;
+    font-size: clamp(1.35rem, 5vw, 2rem);
+    margin: 0.6rem 0 0;
+  }
+
+  .sub {
+    margin: 0.75rem 0 0;
+    max-width: 28rem;
+    opacity: 0.55;
+    font-size: 0.95rem;
+    line-height: 1.6;
+  }
+
+  /* Primary action — a pill button that reads clearly as "go home". */
+  .cta {
+    margin-top: clamp(1.75rem, 5vh, 2.5rem);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.7rem 1.4rem;
+    border: 1px solid color-mix(in srgb, currentColor 28%, transparent);
+    border-radius: 999px;
+    font-size: 0.95rem;
+    transition: border-color 0.25s ease, color 0.25s ease;
+  }
+  .cta:hover { border-color: var(--accent); } /* colour comes from global a:hover */
+
+  .arrow { transition: transform 0.25s ease; }
+  .cta:hover .arrow { transform: translateX(3px); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .arrow { transition: none; }
+  }
+</style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,11 @@
+<script>
+  import { page } from '$app/stores';
+  import ErrorScreen from '$lib/ErrorScreen.svelte';
+</script>
+
+<svelte:head>
+  <title>{$page.status} · paulogdm</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<ErrorScreen status={$page.status} message={$page.error?.message ?? ''} />

--- a/src/routes/404/+page.svelte
+++ b/src/routes/404/+page.svelte
@@ -1,0 +1,12 @@
+<script>
+  import ErrorScreen from '$lib/ErrorScreen.svelte';
+</script>
+
+<svelte:head>
+  <title>404 · paulogdm</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<!-- Prerendered to build/404.html — static hosts (Vercel) serve this for
+     unknown URLs, so the branded content is baked in with no JS or flash. -->
+<ErrorScreen status={404} />


### PR DESCRIPTION
Replaces SvelteKit's default error page with a 404 that matches the site's theme and brand.

## What changed
- **`src/lib/ErrorScreen.svelte`** — shared branded error UI (takes `status` + `message` props). A large monochrome `404` (same colour as the body text), a headline ("This page isn't home." — a nod to the homepage's *"Make yourself at home"* line), a short sub-message, and a pill **"Make yourself at home →"** CTA linking home (arrow nudges on hover). All type is Inter; reduced-motion safe.
- **`src/routes/404/+page.svelte`** — prerenders to `build/404.html`. Static hosts (Vercel) serve this for unknown URLs, so the branded content is **baked in** — no JS dependency, no flash.
- **`src/routes/+error.svelte`** — reuses the same component for runtime errors, passing through the real status/message.

## Why prerender to `404.html`
SvelteKit's `fallback: '404.html'` only emits a ~2KB SPA shell that renders the error client-side (blank-then-hydrate). A dedicated prerendered `/404` route bakes the content into `build/404.html` instead, so it shows instantly. `svelte.config.js` is unchanged (`fallback: null`); the change is purely additive.

## Theme handling
The page respects the visitor's theme via the existing blocking script in `app.html` (already included in the prerendered `404.html`): it uses the saved `lights` cookie if present, otherwise falls back to the OS/browser `prefers-color-scheme`. Verified with no cookie that OS-dark renders dark and OS-light renders light, before first paint.

## Notes for reviewers
- Both routes carry `<meta name="robots" content="noindex">`.
- The headline is an `<h1>`; the global stylesheet has `h1 { font-family: 'Syne' }`, so `.headline` sets Inter explicitly to win on specificity (otherwise it'd render in Syne).

## Verification
Built and checked the prerendered `build/404.html` in headless Chrome:
- Renders correctly under OS dark and OS light with **no cookie**.
- `404` colour matches the body text; all five text elements compute to `"Inter Variable"`.
- CTA links home; zero JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)