### PR TITLE
Sync color theme across tabs via BroadcastChannel

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -65,12 +65,27 @@
   );
   // ── End photo drag resistance ─────────────────────────────────────────────
 
+  // Cross-tab theme sync. Cookies are already shared across same-origin tabs,
+  // so a toggle in one tab leaves the cookie correct everywhere — the channel
+  // just nudges the other tabs to re-render. The sender never receives its own
+  // message, so applyTheme() here can't loop.
+  let themeChannel = null;
+
+  // Single code path for "make the UI reflect `dark`": document classes (which
+  // the canvas renderer reads live) + reactive state (the toggle icon).
+  function applyTheme(dark) {
+    lights = dark;
+    document.documentElement.classList.toggle('theme-dark', dark);
+    document.documentElement.classList.toggle('theme-light', !dark);
+  }
+
   function changeBackground() {
-    lights = !lights;
-    document.documentElement.classList.toggle('theme-dark', lights);
-    document.documentElement.classList.toggle('theme-light', !lights);
+    applyTheme(!lights);
     // SameSite=Lax: this is a first-party preference cookie, never sent cross-site.
     document.cookie = `lights=${lights ? 'on' : 'off'}; path=/; max-age=31536000; SameSite=Lax`;
+    // Notify other tabs/windows; they apply the class + state without re-writing
+    // the cookie or re-broadcasting.
+    themeChannel?.postMessage(lights);
   }
 
   onMount(() => {
@@ -80,6 +95,10 @@
     // system preference) and applied the class before first paint. Sync our
     // reactive state from that single source of truth rather than re-deriving it.
     lights = document.documentElement.classList.contains('theme-dark');
+
+    // Subscribe to theme toggles from other tabs/windows of this origin.
+    themeChannel = new BroadcastChannel('theme');
+    themeChannel.onmessage = (e) => applyTheme(e.data);
 
     let keyBuf = '';
     const KONAMI_SEQ = ['arrowup','arrowup','arrowdown','arrowdown','arrowleft','arrowright','arrowleft','arrowright','b','a'];
@@ -121,6 +140,8 @@
 
     return () => {
       window.removeEventListener('keydown', onKey);
+      themeChannel?.close();
+      themeChannel = null;
       stopRenderer(); // tear down canvas / RAF / resize listener on unmount
     };
   });


### PR DESCRIPTION
## What

Live-sync the light/dark theme across all open tabs and windows of the site. Toggling the theme in one tab now instantly updates every other open tab.

## Why

The theme preference is stored in the `lights` cookie (read by the blocking script in `app.html` before first paint). Cookies are shared across same-origin tabs, but they emit **no change event** — so a toggle in one tab left other tabs showing the stale theme until a manual reload.

## How

Added a `BroadcastChannel('theme')` in `src/routes/+page.svelte`:

- **`changeBackground()`** (the toggle): writes the cookie as before, then `postMessage`s the new state to other tabs.
- **`onMount`**: subscribes to the channel and applies incoming changes.
- Extracted **`applyTheme(dark)`** so the toggle and the receiver share one code path (document classes + reactive `lights` state).

The receiver intentionally does **not** re-write the cookie (it's already shared across tabs) or re-broadcast (`BroadcastChannel` never delivers to the sender) — so there's no echo loop. The channel is closed in the existing `onMount` cleanup.

`app.html` is untouched and remains the first-paint authority for new tabs / SSR.

## Notes for reviewer

- The canvas easter-egg renderer reads the theme class off `<html>` live each frame, so it recolors automatically on a synced change — no extra wiring needed.
- Scope is one file, +24/−3. No new dependencies.

## Verified

Tested against a running dev server, both directions:

| Test | Result |
|---|---|
| Other tab → dark / → light | classes + button icon flip; receiver leaves cookie untouched |
| Echo-loop check | receiver re-broadcasts 0 times |
| Real toggle click (sender) | cookie updated + other tab receives broadcast |
| Console errors | none |

🤖 Generated with [Claude Code](https://claude.com/claude-code)