### PR TITLE
Strip HTML comments from app.html

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -11,17 +11,12 @@
   <link rel="icon" href="/assets/favicon-62.png" sizes="62x62" type="image/png">
   <link rel="apple-touch-icon" href="/assets/favicon-192.png" sizes="192x192">
 
-  <!-- Preload the two dominant above-the-fold faces (Inter body, Syne hero h1)
-       so they're fetched in parallel with fonts.css instead of after it. Geist
-       (the small "Vercel" label) is left to load normally. crossorigin is
-       required for font preloads even when same-origin. -->
   <link rel="preload" href="/vendor/fonts/inter-latin-wght-normal.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/vendor/fonts/syne-latin-400.woff2" as="font" type="font/woff2" crossorigin>
 
 <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="/vendor/fonts.css">
 
-  <!-- Blocking theme script: reads cookie before first paint to prevent FOUC -->
   <script>
     (function () {
       var m = document.cookie.match(/(^| )lights=([^;]+)/);


### PR DESCRIPTION
## What

Removes the two human-authored `<!-- -->` comments in `src/app.html`:
- the font-preload rationale
- the blocking theme-script note

## Why

`app.html` comments pass straight through into the served HTML of every page, so they were visible in view-source on the live site (https://paulogdm.com). They're developer notes that don't belong in shipped output — the rationale already lives in git history (the preload commit and the original theme-script commit).

## Notes for reviewer

- **No behavior change** — only comment lines removed. The `<link rel="preload">` tags and the blocking theme `<script>` are untouched.
- The remaining `<!--[-->`, `<!--[0-->`, `<!--1uha8ag-->` etc. comments in the output are **Svelte 5 hydration markers** — framework-required anchors, not removable without breaking hydration. This PR does not (and can't) touch those.
- Component `.svelte` HTML comments are already stripped by the compiler and never appeared in the output.

## Verified

Against the dev server: no human-readable comments remain in the served HTML, both preload tags still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)