### PR TITLE
Polish entrance + reduced-motion animations

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -90,12 +90,20 @@ a:hover {
 .mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
 
 /* ── Animations (replaces animate.css) ──────────────────────── */
+/* Fade + subtle slide-up. Entrances pair opacity with a small translate so
+   they read as intentional rather than a flat dissolve. */
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0);   }
 }
 
-.animated { animation-duration: 1s; animation-fill-mode: both; }
+/* ease-out (fast in, settle out) is the right curve for content arriving on
+   load; shorter than the old 1s since these fire early and often. */
+.animated {
+  animation-duration: 0.55s;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  animation-fill-mode: both;
+}
 .fadeIn   { animation-name: fadeIn; }
 
 /* ── Theme toggle button ────────────────────────────────────── */
@@ -401,5 +409,17 @@ a:hover {
   .tl-spark::before,
   .tl-spark::after {
     animation: none;
+  }
+
+  /* State changes still happen (hover reveals, theme recolour) — but instantly,
+     with no traversal. Covers the tenure-badge slide, company cross-fades,
+     timeline segment, "now" marker, and the profile-shadow grow. */
+  .tl-company,
+  .tl-company::after,
+  .tl-labels:has(.tl-company:hover) .tl-company:not(:hover),
+  .tl-vercel-seg,
+  .tl-yr-now,
+  .me-size::after {
+    transition: none !important;
   }
 }


### PR DESCRIPTION
## What

Two animation refinements to `static/styles.css`, audited against the [animations.dev vocabulary](https://animations.dev/vocabulary). The site's interaction work (spring-back photo release, tanh rubber-band drag, single-rAF canvas effects, reduced-motion gating of strobe eggs) is already strong — these are polish on top.

### #1 — Entrance animation
- Pair the load-in fade with a subtle `translateY(8px) → 0` slide so entrances read as intentional rather than a flat dissolve.
- Switch from the default symmetric `ease` to an **ease-out** curve (`cubic-bezier(0.16, 1, 0.3, 1)`) — the right curve for content arriving on load.
- Shorten `1s → 0.55s`. These fire early and on every visit, so they should be brief (per the vocab's "frequency of use" principle).
- The error screen reuses `.animated`, so its 404 copy/CTA inherit the same upgrade for free.

### #4 — Reduced motion
Neutralize the remaining motion-bearing **transitions** so state changes happen instantly instead of traversing, for users with `prefers-reduced-motion: reduce`:
- tenure-badge slide
- company label cross-fades
- timeline Vercel segment
- "now" marker recolor
- profile-photo shadow grow

Reveals and recolors still work — they just no longer move. (The strobe-heavy canvas easter eggs were already gated in JS.)

## Why

Transform/opacity entrances stay on the GPU compositor path, and ease-out + a short slide is the standard for UI arriving on screen. The reduced-motion additions close the gap between the JS-gated effects and the CSS transitions, which previously still animated.

## Notes for reviewer
- One file changed: `static/styles.css` (+23 / −3).
- Deliberately **not** included: aligning `h1`'s 1s color transition to the 0.3s body transition on theme toggle (a separate, debatable call — left for the author).
- Reduced-motion users get `animation: none`, so they see no entrance slide at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)