### PR TITLE
feat: anchor brand waves to company logos with hover reveal

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -368,6 +368,15 @@
                       : null;
     if (highlightEl) highlightEl.classList.add('tl-company--lit');
 
+    // Brand waves emanate from the company's logo on the timeline rather than the
+    // "now" spark, so the ripple visibly originates at the Vercel ▲ / Clerk ◐ mark.
+    const brandSvg = highlightEl?.querySelector('svg');
+    if (brandSvg) {
+      const r = brandSvg.getBoundingClientRect();
+      cx = r.left + r.width  / 2;
+      cy = r.top  + r.height / 2;
+    }
+
     let sources      = buildSources(cx, cy, fxW, fxH, SPEED);
     let rainbowGrads = variant === 'rainbow' ? buildRainbowGrads(fxCtx, sources) : null;
 
@@ -496,6 +505,24 @@
         continue;
       }
 
+      if (variant === 'clerk') {
+        if (bornAt !== 0) continue;  // single expanding circle, no reflections
+        // Clerk's mark is monochrome (black/grey/white), so the wave borrows the
+        // vercel colours: white ring on dark, black on light. Read the theme live
+        // so a mid-wave toggle recolours correctly (same approach as vercel/mono).
+        const rgb = document.documentElement.classList.contains('theme-dark') ? '255,255,255' : '0,0,0';
+        ctx.beginPath();
+        ctx.arc(sx, sy, r, 0, Math.PI * 2);
+        ctx.strokeStyle = `rgba(${rgb},${alpha.toFixed(3)})`;
+        ctx.lineWidth   = 2;
+        ctx.shadowBlur  = 20;
+        ctx.shadowColor = `rgba(${rgb},${(alpha * 0.6).toFixed(3)})`;
+        ctx.stroke();
+        ctx.shadowBlur  = 0;
+        ctx.shadowColor = 'transparent';
+        continue;
+      }
+
       if (variant === 'ghost') {
         // Three-pass layered glow: wide bloom → mid halo → bright core.
         // 11: blur radii capped (was 48/22/8) — large shadowBlur is the most
@@ -533,10 +560,6 @@
         color     = `rgba(255,210,0,${alpha.toFixed(3)})`;
         lineWidth = 2;
         ctx.shadowBlur = 14; ctx.shadowColor = `rgba(255,210,0,${(alpha * 0.7).toFixed(3)})`;
-      } else if (variant === 'clerk') {
-        color     = `rgba(108,71,255,${alpha.toFixed(3)})`;
-        lineWidth = 2;
-        ctx.shadowBlur = 14; ctx.shadowColor = `rgba(108,71,255,${(alpha * 0.7).toFixed(3)})`;
       } else {
         color     = `rgba(255,102,0,${alpha.toFixed(3)})`; // default
         lineWidth = 1;

--- a/static/styles.css
+++ b/static/styles.css
@@ -196,12 +196,15 @@ a:hover {
   transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
-.tl-company:hover::after {
+.tl-company:hover::after,
+.tl-company--lit::after {
   opacity: 1;
   transform: translateY(-50%) translateX(0);
 }
 
-/* Brand wave highlight — applied via JS while the wave is alive */
+/* Brand wave highlight — applied via JS while the wave is alive. It mirrors the
+   hover state (tenure badge, recolour, cross-fade, timeline cue) for as long as
+   the wave lives, so a Clerk/Vercel wave reveals the same detail as a hover. */
 .tl-company--lit {
   color: var(--accent) !important;
 }
@@ -211,16 +214,19 @@ a:hover {
   transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1),
               color   0.6s ease;
 }
-.tl-labels:has(.tl-company:hover) .tl-company:not(:hover) {
+.tl-labels:has(.tl-company:hover) .tl-company:not(:hover),
+.tl-labels:has(.tl-company--lit) .tl-company:not(.tl-company--lit) {
   opacity: 0;
   transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* Highlight the relevant timeline piece on hover */
-.tl-labels:has(.tl-vercel:hover) ~ .tl-track .tl-vercel-seg {
+/* Highlight the relevant timeline piece on hover (or while a brand wave is lit) */
+.tl-labels:has(.tl-vercel:hover) ~ .tl-track .tl-vercel-seg,
+.tl-labels:has(.tl-vercel.tl-company--lit) ~ .tl-track .tl-vercel-seg {
   opacity: 1;
 }
-.tl-labels:has(.tl-clerk:hover) ~ .tl-track .tl-spark {
+.tl-labels:has(.tl-clerk:hover) ~ .tl-track .tl-spark,
+.tl-labels:has(.tl-clerk.tl-company--lit) ~ .tl-track .tl-spark {
   box-shadow: 0 0 8px 3px var(--accent), 0 0 22px 10px var(--accent-glow);
 }
 
@@ -322,7 +328,8 @@ a:hover {
   transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.tl-labels:has(.tl-clerk:hover) ~ .tl-years .tl-yr-now {
+.tl-labels:has(.tl-clerk:hover) ~ .tl-years .tl-yr-now,
+.tl-labels:has(.tl-clerk.tl-company--lit) ~ .tl-years .tl-yr-now {
   opacity: 1;
 }
 


### PR DESCRIPTION
## What & why

The Vercel/Clerk sonar-wave easter eggs used to ripple out from the shared **"now"** spark on the timeline. This re-anchors each brand wave to that company's own logo, makes the Clerk wave match its rebrand, and ties the timeline's hover affordance to the wave's lifetime.

## Changes

- **Wave origin from the logo** — `spawnWave` now overrides the origin to the center of the lit company's `<svg>`, so the ripple emanates from the Vercel ▲ / Clerk mark rather than the "now" spark. Done centrally, so every trigger (keyboard `vercel`/`clerk`, `sonar` all-waves, random spark click) is covered.
- **Clerk wave restyle** — Clerk's mark is now monochrome (black/grey/white), so the wave is a theme-aware circle (white on dark, black on light) reusing the Vercel color/glow treatment, replacing the old purple ring.
- **Lit = hover** — while a brand wave is alive, `.tl-company--lit` now mirrors the `:hover` state in `static/styles.css`: the tenure badge appears, the other company fades, and the matching timeline cue lights up (Vercel segment / Clerk spark glow + "now" marker) — until the wave dies.

## Verification

Verified against a local dev server by sampling the rendered canvas:
- Vercel triangle midline and Clerk circle centroid land exactly on their respective logo SVGs (0px off; ~46–339px away from the spark).
- Clerk wave measures as a full 360° circle in the active theme ink color.
- During a wave, the lit company's tenure badge, sibling fade, and timeline cues activate via the new `--lit` rules (confirmed in the CSSOM + computed styles).

## Reviewer notes

- `static/styles.css` is a static asset and does **not** hot-reload — hard-refresh to see CSS changes locally.