### PR TITLE
Fix contact link, hero image priority, and SEO metadata

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Paulogdm personal page. Make yourself at home. Twitter, GitHub and StackOverflow profiles.">
+  <meta name="description" content="Paulo G. De Mitri (paulogdm) — Sr. Technical Account Manager at Clerk, previously Vercel. Find me on X, LinkedIn, GitHub and Stack Overflow, or book a call.">
   <meta name="author" content="paulogdm">
 
   <link rel="icon" href="/assets/favicon-32.png" sizes="32x32" type="image/png">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -780,6 +780,28 @@
     left:  tlPct(new Date(y, 0, 1)),
   }));
 
+  // schema.org Person — lets search engines render paulogdm as an entity and
+  // ties the social links together via sameAs. Emitted as a raw <script> in
+  // <svelte:head> through {@html} (a literal <script> tag there is captured by
+  // the compiler as a component script instead of being rendered as markup).
+  const personJsonLd = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Paulo G. De Mitri',
+    alternateName: 'paulogdm',
+    url: 'https://paulogdm.com',
+    image: 'https://paulogdm.com/assets/me.jpg',
+    jobTitle: 'Sr. Technical Account Manager',
+    worksFor: { '@type': 'Organization', name: 'Clerk', url: 'https://clerk.com' },
+    email: 'mailto:me@paulogdm.com',
+    sameAs: [
+      'https://x.com/paulogdm',
+      'https://www.linkedin.com/in/paulogdm/',
+      'https://github.com/paulogdm',
+      'https://stackoverflow.com/users/2665655/paulogdm',
+    ],
+  });
+
 </script>
 
 <svelte:head>
@@ -793,6 +815,7 @@
   <meta property="og:image:height" content="630" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@paulogdm" />
+  {@html `<script type="application/ld+json">${personJsonLd}</script>`}
 </svelte:head>
 
 <div class="container">
@@ -819,8 +842,7 @@
         width="500"
         height="500"
         draggable="false"
-        fetchpriority="low"
-        decoding="async"
+        fetchpriority="high"
         style={photoStyle}
         onpointerdown={onPhotoDragStart}
         onpointermove={onPhotoMove}
@@ -832,7 +854,7 @@
     <div class="my-5 py-2 animated fadeIn" style="animation-delay: 0.25s">
       <h1>paulogdm</h1>
       <nav class="social-links mt-3" aria-label="Social media and contact links">
-        <a class="mx-2" href="&#77;&#97;&#73;&#76;&#84;&#79;&#58;&#109;&#101;&#64;&#112;&#97;&#117;&#108;&#111;&#103;&#100;&#109;&#46;&#99;&#111;&#109;" target="_blank" rel="noopener noreferrer" aria-label="Email">
+        <a class="mx-2" href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#109;&#101;&#64;&#112;&#97;&#117;&#108;&#111;&#103;&#100;&#109;&#46;&#99;&#111;&#109;" aria-label="Email">
           <Icon icon={mailIcon} width="1.33em" />
         </a>
         <a class="mx-2" href="https://x.com/paulogdm" target="_blank" rel="noopener noreferrer" aria-label="X">


### PR DESCRIPTION
Small fixes to the contact link, hero image loading priority, and the page's SEO/structured-data metadata.

## Changes
- **Email link** — corrected the `MaILTO:` scheme to `mailto:` (kept the HTML-entity anti-scraper encoding) and dropped `target="_blank"`/`rel` on a `mailto:`, which only left a blank tab behind.
- **Hero photo** — set `fetchpriority="high"` and removed `decoding="async"`. The avatar is the LCP element, so deprioritizing it worked against above-the-fold paint.
- **Meta description** — refreshed the stale copy (it still named an old "Twitter" profile); now reflects the current links (X, LinkedIn, GitHub, Stack Overflow, email, cal.com) plus name and role.
- **Person JSON-LD** — added schema.org `Person` structured data with `sameAs` social links so search engines can render paulogdm as an entity. Emitted via `{@html}` in `<svelte:head>` (a literal `<script>` tag there gets captured by the Svelte compiler).

## Verification
Validated against the running dev preview: email `href` is `mailto:` with no `target`/`rel`, photo carries `fetchpriority="high"` and no `decoding`, meta description is current, and the JSON-LD parses as a valid `Person` with 4 `sameAs` links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)